### PR TITLE
Temporarily disable dynver git tag check

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -465,9 +465,10 @@ def internalProject(projectId: String, additionalSettings: sbt.Def.SettingsDefin
 
 Global / onLoad := (Global / onLoad).value.andThen { s =>
   val v = version.value
+  val log = sLog.value
   if (dynverGitDescribeOutput.value.hasNoTags)
-    throw new MessageOnlyException(
-      s"Failed to derive version from git tags. Maybe run `git fetch --unshallow`? Derived version: $v"
+    log.error(
+      s"Failed to derive version from git tags. Maybe run `git fetch --unshallow` or `git fetch upstream` on a fresh git clone from a fork? Derived version: $v"
     )
   s
 }


### PR DESCRIPTION
This check is causing sbt to load with the following error
```
[error] Failed to derive version from git tags. Maybe run `git fetch --unshallow`? Derived version: 0.0.0+2675-8c31b4d7-SNAPSHOT
```

Since there aren't any tags in the new incubator-pekko repo. The PR disables the check so that sbt can actually start