### PR TITLE
Add .git-blame-ignore-revs file containing format commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# scalafmt
+433daa5c5b0b2c3f85c6f1c7e62a4f4171856468


### PR DESCRIPTION
Similar to pekko core, adds a `.git-blame-ignore-revs` which contains the hashes for the previous scalafmt commits.