### PR TITLE
Add documentation for git blame on ignoring formatting commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,15 @@ Example:
     * Details 2
     * Details 3
 
+### Ignoring formatting commits in git blame
+
+Throughout the history of the codebase various formatting commits have been applied as the scalafmt style has evolved over time, if desired
+one can setup git blame to ignore these commits. The hashes for these specific are stored in [this file](.git-blame-ignore-revs) so to configure
+git blame to ignore these commits you can execute the following.
+
+```shell
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
 
 ## How To Enforce These Guidelines?
 


### PR DESCRIPTION
PR title is self explanatory, this is a follow on from https://github.com/apache/incubator-pekko-connectors/pull/14.