### PR TITLE
fix issue with license headers

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -37,11 +37,11 @@ jobs:
           jvm: adopt:8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.3.3
+        uses: coursier/cache-action@v6.4.0
 
       # temporarily remove mima checks
-      - name: "Code style, compile tests, MiMa. Run locally with: sbt +~2.13 \"verifyCodeStyle; Test/compile; mimaReportBinaryIssues\""
-        run: sbt +~2.13 "verifyCodeStyle; Test/compile"
+      - name: "Code style, compile tests, MiMa. Run locally with: sbt +~2.13 \"headerCheckAll; verifyCodeFmt; Test/compile; mimaReportBinaryIssues\""
+        run: sbt +~2.13 "headerCheckAll; verifyCodeFmt; Test/compile"
 
   documentation:
     name: ScalaDoc, Documentation with Paradox
@@ -65,7 +65,7 @@ jobs:
           jvm: adopt:11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.3.3
+        uses: coursier/cache-action@v6.4.0
 
       - name: "Create all API docs and create site with Paradox"
         run: sbt docs/makeSite
@@ -153,7 +153,7 @@ jobs:
 
       - name: Cache Coursier cache
         if: env.execute_build == 'true'
-        uses: coursier/cache-action@v6.3.3
+        uses: coursier/cache-action@v6.4.0
 
       - name: ${{ matrix.connector }}
         if: env.execute_build == 'true'

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectionProvidersTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpConnectorsTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpFlowTest.java
+++ b/amqp/src/test/java/akka/stream/alpakka/amqp/javadsl/AmqpFlowTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/resources/application.conf
+++ b/amqp/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpProxyConnection.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpProxyConnection.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/AmqpSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectionProvidersSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectionProvidersSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpFlowSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpFlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpGraphStageLogicConnectionShutdownSpec.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpGraphStageLogicConnectionShutdownSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpMocking.scala
+++ b/amqp/src/test/scala/akka/stream/alpakka/amqp/scaladsl/AmqpMocking.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/amqp/src/test/scala/docs/scaladsl/AmqpDocsSpec.scala
+++ b/amqp/src/test/scala/docs/scaladsl/AmqpDocsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
+++ b/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/avroparquet/src/test/java/docs/javadsl/Examples.java
+++ b/avroparquet/src/test/java/docs/javadsl/Examples.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/avroparquet/src/test/resources/application.conf
+++ b/avroparquet/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AbstractAvroParquet.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetFlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSinkSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
+++ b/avroparquet/src/test/scala/docs/scaladsl/AvroParquetSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/aws-event-bridge/src/test/java/docs/javadsl/EventBridgePublisherTest.java
+++ b/aws-event-bridge/src/test/java/docs/javadsl/EventBridgePublisherTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/aws-event-bridge/src/test/resources/application.conf
+++ b/aws-event-bridge/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/aws-event-bridge/src/test/scala/akka/stream/alpakka/aws/eventbridge/DefaultTestContext.scala
+++ b/aws-event-bridge/src/test/scala/akka/stream/alpakka/aws/eventbridge/DefaultTestContext.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/aws-event-bridge/src/test/scala/akka/stream/alpakka/aws/eventbridge/EventBridgePublishMockSpec.scala
+++ b/aws-event-bridge/src/test/scala/akka/stream/alpakka/aws/eventbridge/EventBridgePublishMockSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/aws-event-bridge/src/test/scala/akka/stream/alpakka/aws/eventbridge/IntegrationTestContext.scala
+++ b/aws-event-bridge/src/test/scala/akka/stream/alpakka/aws/eventbridge/IntegrationTestContext.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/aws-event-bridge/src/test/scala/docs/scaladsl/EventBridgePublisherSpec.scala
+++ b/aws-event-bridge/src/test/scala/docs/scaladsl/EventBridgePublisherSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/awslambda/src/test/java/docs/javadsl/AwsLambdaFlowTest.java
+++ b/awslambda/src/test/java/docs/javadsl/AwsLambdaFlowTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/awslambda/src/test/java/docs/javadsl/Examples.java
+++ b/awslambda/src/test/java/docs/javadsl/Examples.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/awslambda/src/test/resources/application.conf
+++ b/awslambda/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/awslambda/src/test/scala/docs/scaladsl/AwsLambdaFlowSpec.scala
+++ b/awslambda/src/test/scala/docs/scaladsl/AwsLambdaFlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/awslambda/src/test/scala/docs/scaladsl/Examples.scala
+++ b/awslambda/src/test/scala/docs/scaladsl/Examples.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
+++ b/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/azure-storage-queue/src/test/resources/application.conf
+++ b/azure-storage-queue/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
+++ b/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/build.sbt
+++ b/build.sbt
@@ -101,8 +101,6 @@ TaskKey[Unit]("verifyCodeFmt") := {
   }
 }
 
-addCommandAlias("verifyCodeStyle", "headerCheck; verifyCodeFmt")
-
 lazy val amqp = pekkoConnectorProject("amqp", "amqp", Dependencies.Amqp)
 
 lazy val avroparquet =

--- a/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cassandra/src/test/java/docs/javadsl/CassandraTestHelper.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraTestHelper.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cassandra/src/test/resources/application.conf
+++ b/cassandra/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraLifecycle.scala
+++ b/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraLifecycle.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSessionPerformanceSpec.scala
+++ b/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSessionPerformanceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSpecBase.scala
+++ b/cassandra/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSpecBase.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cassandra/src/test/scala/docs/javadsl/CassandraSessionSpec.scala
+++ b/cassandra/src/test/scala/docs/javadsl/CassandraSessionSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cassandra/src/test/scala/docs/scaladsl/AkkaDiscoverySpec.scala
+++ b/cassandra/src/test/scala/docs/scaladsl/AkkaDiscoverySpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cassandra/src/test/scala/docs/scaladsl/CassandraFlowSpec.scala
+++ b/cassandra/src/test/scala/docs/scaladsl/CassandraFlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/cassandra/src/test/scala/docs/scaladsl/CassandraSourceSpec.scala
+++ b/cassandra/src/test/scala/docs/scaladsl/CassandraSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
+++ b/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/couchbase/src/test/resources/application.conf
+++ b/couchbase/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/couchbase/src/test/resources/discovery.conf
+++ b/couchbase/src/test/resources/discovery.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
+++ b/couchbase/src/test/scala/akka/stream/alpakka/couchbase/testing/CouchbaseSupport.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseFlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseSessionExamplesSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/couchbase/src/test/scala/docs/scaladsl/CouchbaseSourceSpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/CouchbaseSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
+++ b/couchbase/src/test/scala/docs/scaladsl/DiscoverySpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/csv/src/test/java/docs/javadsl/CsvParsingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvParsingTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/csv/src/test/java/docs/javadsl/CsvToMapTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvToMapTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/csv/src/test/resources/application.conf
+++ b/csv/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvFormatterSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvFormatterSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/akka/stream/alpakka/csv/CsvParserSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/csv/src/test/scala/docs/scaladsl/CsvFormattingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvFormattingSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/csv/src/test/scala/docs/scaladsl/CsvSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvToMapSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/doc-examples/src/test/java/akka/stream/alpakka/eip/javadsl/PassThroughExamples.java
+++ b/doc-examples/src/test/java/akka/stream/alpakka/eip/javadsl/PassThroughExamples.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/doc-examples/src/test/scala/akka/stream/alpakka/eip/scaladsl/PassThroughExamples.scala
+++ b/doc-examples/src/test/scala/akka/stream/alpakka/eip/scaladsl/PassThroughExamples.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/dynamodb/src/test/java/docs/javadsl/RetryTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/RetryTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/dynamodb/src/test/resources/application.conf
+++ b/dynamodb/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ItemSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/ItemSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TableSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TestOps.scala
+++ b/dynamodb/src/test/scala/akka/stream/alpakka/dynamodb/TestOps.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/ExampleSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
+++ b/dynamodb/src/test/scala/docs/scaladsl/RetrySpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchParameterizedTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchParameterizedTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV7Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV7Test.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/java/docs/javadsl/OpensearchParameterizedTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/OpensearchParameterizedTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/java/docs/javadsl/OpensearchV1Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/OpensearchV1Test.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/resources/application.conf
+++ b/elasticsearch/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchParamsSpec.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/ElasticsearchParamsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStageTest.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSimpleFlowStageTest.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourcStageTest.scala
+++ b/elasticsearch/src/test/scala/akka/stream/alpakka/elasticsearch/impl/ElasticsearchSourcStageTest.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchConnectorBehaviour.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchConnectorBehaviour.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpecBase.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpecBase.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpecUtils.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpecUtils.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV7Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV7Spec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/OpensearchConnectorBehaviour.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/OpensearchConnectorBehaviour.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/elasticsearch/src/test/scala/docs/scaladsl/OpensearchV1Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/OpensearchV1Spec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/java/docs/javadsl/ArchiveHelper.java
+++ b/file/src/test/java/docs/javadsl/ArchiveHelper.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/java/docs/javadsl/ArchiveTest.java
+++ b/file/src/test/java/docs/javadsl/ArchiveTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/java/docs/javadsl/DirectoryChangesSourceTest.java
+++ b/file/src/test/java/docs/javadsl/DirectoryChangesSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/java/docs/javadsl/DirectoryTest.java
+++ b/file/src/test/java/docs/javadsl/DirectoryTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/java/docs/javadsl/FileTailSourceTest.java
+++ b/file/src/test/java/docs/javadsl/FileTailSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
+++ b/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/java/docs/javadsl/NestedTarReaderTest.java
+++ b/file/src/test/java/docs/javadsl/NestedTarReaderTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/resources/application.conf
+++ b/file/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntrySpec.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/TarArchiveEntrySpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
+++ b/file/src/test/scala/akka/stream/alpakka/file/impl/archive/ZipArchiveFlowTest.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/scala/docs/scaladsl/DirectoryChangesSourceSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/DirectoryChangesSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/scala/docs/scaladsl/DirectorySpec.scala
+++ b/file/src/test/scala/docs/scaladsl/DirectorySpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/scala/docs/scaladsl/ExecutableUtils.scala
+++ b/file/src/test/scala/docs/scaladsl/ExecutableUtils.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/FileTailSourceExtrasSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/scala/docs/scaladsl/FileTailSourceSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/FileTailSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/LogRotatorSinkSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/AkkaSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/AkkaSupport.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/BaseFtpSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/BaseFtpSupport.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/BaseSftpSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/BaseSftpSupport.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/BaseSupport.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/BaseSupport.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/BaseSupportImpl.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/BaseSupportImpl.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/CommonFtpStageTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpStageTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpWithProxyStageTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsStageTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/FtpsWithProxyStageTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/KeyFileSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/KeyFileSftpSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/RawKeySftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/RawKeySftpSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/SftpStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/SftpStageTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/SftpWithProxyStageTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/SftpWithProxyStageTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
+++ b/ftp/src/test/java/akka/stream/alpakka/ftp/StrictHostCheckingSftpSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java
+++ b/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/docs/javadsl/FtpMkdirExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpMkdirExample.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/docs/javadsl/FtpMovingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpMovingExample.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/docs/javadsl/FtpProcessAndMoveExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpProcessAndMoveExample.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/docs/javadsl/FtpRemovingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpRemovingExample.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/docs/javadsl/FtpRetrievingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpRetrievingExample.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/docs/javadsl/FtpTraversingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpTraversingExample.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/docs/javadsl/FtpWritingTest.java
+++ b/ftp/src/test/java/docs/javadsl/FtpWritingTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java
+++ b/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/resources/application.conf
+++ b/ftp/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/ftp/src/test/resources/squid.conf
+++ b/ftp/src/test/resources/squid.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 debug_options ALL,2
 
 http_port 3128

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseFtpsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSftpSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/BaseSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
+++ b/ftp/src/test/scala/akka/stream/alpakka/ftp/CommonFtpStageSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
+++ b/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala
+++ b/ftp/src/test/scala/docs/scaladsl/scalaExamples.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/java/docs/javadsl/Animal.java
+++ b/geode/src/test/java/docs/javadsl/Animal.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/java/docs/javadsl/AnimalPdxSerializer.java
+++ b/geode/src/test/java/docs/javadsl/AnimalPdxSerializer.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/java/docs/javadsl/Person.java
+++ b/geode/src/test/java/docs/javadsl/Person.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/java/docs/javadsl/PersonPdxSerializer.java
+++ b/geode/src/test/java/docs/javadsl/PersonPdxSerializer.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/resources/application.conf
+++ b/geode/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/geode/src/test/scala/akka/stream/alpakka/geode/impl/pdx/PDXDecoderSpec.scala
+++ b/geode/src/test/scala/akka/stream/alpakka/geode/impl/pdx/PDXDecoderSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/scala/akka/stream/alpakka/geode/impl/pdx/PDXEncodeSpec.scala
+++ b/geode/src/test/scala/akka/stream/alpakka/geode/impl/pdx/PDXEncodeSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/scala/akka/stream/alpakka/geode/impl/pdx/PdxWriterMock.scala
+++ b/geode/src/test/scala/akka/stream/alpakka/geode/impl/pdx/PdxWriterMock.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/scala/docs/scaladsl/GeodeBaseSpec.scala
+++ b/geode/src/test/scala/docs/scaladsl/GeodeBaseSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/scala/docs/scaladsl/GeodeContinuousSourceSpec.scala
+++ b/geode/src/test/scala/docs/scaladsl/GeodeContinuousSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/scala/docs/scaladsl/GeodeFiniteSourceSpec.scala
+++ b/geode/src/test/scala/docs/scaladsl/GeodeFiniteSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/scala/docs/scaladsl/GeodeFlowSpec.scala
+++ b/geode/src/test/scala/docs/scaladsl/GeodeFlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/scala/docs/scaladsl/GeodeSinkSpec.scala
+++ b/geode/src/test/scala/docs/scaladsl/GeodeSinkSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/scala/docs/scaladsl/Model.scala
+++ b/geode/src/test/scala/docs/scaladsl/Model.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/geode/src/test/scala/docs/scaladsl/PersonPdxSerializer.scala
+++ b/geode/src/test/scala/docs/scaladsl/PersonPdxSerializer.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/java/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/AvroByteStringDecoder.scala
+++ b/google-cloud-bigquery-storage/src/test/java/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/AvroByteStringDecoder.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/java/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/BigQueryStorageSpec.java
+++ b/google-cloud-bigquery-storage/src/test/java/akka/stream/alpakka/googlecloud/bigquery/storage/javadsl/BigQueryStorageSpec.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/java/docs/javadsl/ExampleReader.java
+++ b/google-cloud-bigquery-storage/src/test/java/docs/javadsl/ExampleReader.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/resources/application.conf
+++ b/google-cloud-bigquery-storage/src/test/resources/application.conf
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka.http.server.preview.enable-http2 = on

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/BigQueryStorageSpecBase.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/BigQueryStorageSpecBase.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/mock/BigQueryMockData.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/mock/BigQueryMockData.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/mock/BigQueryMockServer.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/mock/BigQueryMockServer.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/ArrowByteStringDecoder.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/ArrowByteStringDecoder.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/AvroByteStringDecoder.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/AvroByteStringDecoder.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/BigQueryArrowStorageSpec.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/BigQueryArrowStorageSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/BigQueryAvroStorageSpec.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/BigQueryAvroStorageSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/BigQueryStorageSpec.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/storage/scaladsl/BigQueryStorageSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery-storage/src/test/scala/docs/scaladsl/ExampleReader.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/docs/scaladsl/ExampleReader.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/java/akka/stream/alpakka/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
+++ b/google-cloud-bigquery/src/test/java/akka/stream/alpakka/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/java/docs/javadsl/BigQueryDoc.java
+++ b/google-cloud-bigquery/src/test/java/docs/javadsl/BigQueryDoc.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/resources/application.conf
+++ b/google-cloud-bigquery/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 alpakka.google {
 
   credentials {

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/HoverflySupport.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/HoverflySupport.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/A.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/A.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/javadsl/EndToEndHelper.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/javadsl/EndToEndHelper.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/scaladsl/BigQueryEndToEndSpec.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/scaladsl/BigQueryEndToEndSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/scaladsl/EndToEndHelper.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/e2e/scaladsl/EndToEndHelper.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/BigQueryQueriesSpec.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/BigQueryQueriesSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/schema/BigQuerySchemasSpec.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/schema/BigQuerySchemasSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/spray/BigQueryJsonProtocolSpec.scala
+++ b/google-cloud-bigquery/src/test/scala/akka/stream/alpakka/googlecloud/bigquery/scaladsl/spray/BigQueryJsonProtocolSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-bigquery/src/test/scala/docs/scaladsl/BigQueryDoc.scala
+++ b/google-cloud-bigquery/src/test/scala/docs/scaladsl/BigQueryDoc.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
+++ b/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-pub-sub-grpc/src/test/resources/application.conf
+++ b/google-cloud-pub-sub-grpc/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/ExampleApp.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/ExampleApp.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
+++ b/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-pub-sub/src/test/resources/application.conf
+++ b/google-cloud-pub-sub/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/GooglePubSubSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/ModelSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/ModelSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApiSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/PubSubApiSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/TestCredentials.scala
+++ b/google-cloud-pub-sub/src/test/scala/akka/stream/alpakka/googlecloud/pubsub/impl/TestCredentials.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-pub-sub/src/test/scala/docs/scaladsl/ExampleUsage.scala
+++ b/google-cloud-pub-sub/src/test/scala/docs/scaladsl/ExampleUsage.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-pub-sub/src/test/scala/docs/scaladsl/IntegrationSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/docs/scaladsl/IntegrationSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
+++ b/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-storage/src/test/resources/application.conf
+++ b/google-cloud-storage/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.testkit.TestEventListener", "akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSExtSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCSSettingsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageExtSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/GCStorageSettingsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/WithMaterializerGlobal.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/WithMaterializerGlobal.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorageWiremockBase.scala
+++ b/google-cloud-storage/src/test/scala/akka/stream/alpakka/googlecloud/storage/scaladsl/GCStorageWiremockBase.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala
+++ b/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSinkSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala
+++ b/google-cloud-storage/src/test/scala/docs/scaladsl/GCStorageSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/java/docs/javadsl/GoogleCommonDoc.java
+++ b/google-common/src/test/java/docs/javadsl/GoogleCommonDoc.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/resources/application.conf
+++ b/google-common/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 alpakka.google {
 
   credentials {

--- a/google-common/src/test/scala/akka/stream/alpakka/google/GoogleHttpException.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/GoogleHttpException.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/scala/akka/stream/alpakka/google/GoogleSettingsSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/GoogleSettingsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/scala/akka/stream/alpakka/google/HoverflySupport.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/HoverflySupport.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/scala/akka/stream/alpakka/google/PaginatedRequestSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/PaginatedRequestSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/scala/akka/stream/alpakka/google/ResumableUploadSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/ResumableUploadSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/scala/akka/stream/alpakka/google/auth/GoogleOAuth2Spec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/auth/GoogleOAuth2Spec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/scala/akka/stream/alpakka/google/auth/OAuth2CredentialsSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/auth/OAuth2CredentialsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/scala/akka/stream/alpakka/google/http/GoogleHttpSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/http/GoogleHttpSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/scala/akka/stream/alpakka/google/util/AnnotateLastSpec.scala
+++ b/google-common/src/test/scala/akka/stream/alpakka/google/util/AnnotateLastSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala
+++ b/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-fcm/src/test/java/docs/javadsl/FcmExamples.java
+++ b/google-fcm/src/test/java/docs/javadsl/FcmExamples.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-fcm/src/test/resources/application.conf
+++ b/google-fcm/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.testkit.TestEventListener", "akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/v1/ConditionBuilderSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/v1/ConditionBuilderSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/v1/FcmNotificationSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/v1/FcmNotificationSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/v1/impl/FcmSenderSpec.scala
+++ b/google-fcm/src/test/scala/akka/stream/alpakka/google/firebase/fcm/v1/impl/FcmSenderSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/google-fcm/src/test/scala/docs/scaladsl/FcmExamples.scala
+++ b/google-fcm/src/test/scala/docs/scaladsl/FcmExamples.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/hbase/src/test/resources/reference.conf
+++ b/hbase/src/test/resources/reference.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/hbase/src/test/scala/docs/scaladsl/HBaseStageSpec.scala
+++ b/hbase/src/test/scala/docs/scaladsl/HBaseStageSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/hdfs/src/test/java/docs/javadsl/HdfsWriterTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsWriterTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/hdfs/src/test/resources/application.conf
+++ b/hdfs/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka.stream.akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/hdfs/src/test/scala/akka/stream/alpakka/hdfs/util/TestUtils.scala
+++ b/hdfs/src/test/scala/akka/stream/alpakka/hdfs/util/TestUtils.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/hdfs/src/test/scala/docs/scaladsl/HdfsReaderSpec.scala
+++ b/hdfs/src/test/scala/docs/scaladsl/HdfsReaderSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
+++ b/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/huawei-push-kit/src/test/java/docs/javadsl/PushKitExamples.java
+++ b/huawei-push-kit/src/test/java/docs/javadsl/PushKitExamples.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/huawei-push-kit/src/test/resources/application.conf
+++ b/huawei-push-kit/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.testkit.TestEventListener", "akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/ConditionBuilderSpec.scala
+++ b/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/ConditionBuilderSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/impl/HmsTokenApiSpec.scala
+++ b/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/impl/HmsTokenApiSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/impl/PushKitSenderSpec.scala
+++ b/huawei-push-kit/src/test/scala/akka/stream/alpakka/huawei/pushkit/impl/PushKitSenderSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/huawei-push-kit/src/test/scala/docs/scaladsl/PushKitExamples.scala
+++ b/huawei-push-kit/src/test/scala/docs/scaladsl/PushKitExamples.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/java/docs/javadsl/Cpu.java
+++ b/influxdb/src/test/java/docs/javadsl/Cpu.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbCpu.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbCpu.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbSourceCpu.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbSourceCpu.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbSourceTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/java/docs/javadsl/TestConstants.java
+++ b/influxdb/src/test/java/docs/javadsl/TestConstants.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/java/docs/javadsl/TestUtils.java
+++ b/influxdb/src/test/java/docs/javadsl/TestUtils.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/resources/application.conf
+++ b/influxdb/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka.stream.akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/influxdb/src/test/scala/docs/scaladsl/FlowSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/FlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbFlowCpu.java
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbFlowCpu.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSourceCpu.java
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSourceCpu.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSourceSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpecCpu.java
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpecCpu.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/java/akka/stream/alpakka/ironmq/UnitTest.java
+++ b/ironmq/src/test/java/akka/stream/alpakka/ironmq/UnitTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/java/akka/stream/alpakka/ironmq/javadsl/IronMqConsumerTest.java
+++ b/ironmq/src/test/java/akka/stream/alpakka/ironmq/javadsl/IronMqConsumerTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/java/docs/javadsl/IronMqDocsTest.java
+++ b/ironmq/src/test/java/docs/javadsl/IronMqDocsTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/resources/application.conf
+++ b/ironmq/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 alpakka.ironmq {
 
   endpoint = "http://localhost:8080"

--- a/ironmq/src/test/scala/akka/stream/alpakka/ironmq/IronMqSpec.scala
+++ b/ironmq/src/test/scala/akka/stream/alpakka/ironmq/IronMqSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/scala/akka/stream/alpakka/ironmq/impl/IronMqClientForTests.scala
+++ b/ironmq/src/test/scala/akka/stream/alpakka/ironmq/impl/IronMqClientForTests.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/scala/akka/stream/alpakka/ironmq/impl/IronMqClientSpec.scala
+++ b/ironmq/src/test/scala/akka/stream/alpakka/ironmq/impl/IronMqClientSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/scala/akka/stream/alpakka/ironmq/impl/IronMqPullStageSpec.scala
+++ b/ironmq/src/test/scala/akka/stream/alpakka/ironmq/impl/IronMqPullStageSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/scala/akka/stream/alpakka/ironmq/impl/IronMqPushStageSpec.scala
+++ b/ironmq/src/test/scala/akka/stream/alpakka/ironmq/impl/IronMqPushStageSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/scala/akka/stream/alpakka/ironmq/scaladsl/IronMqConsumerSpec.scala
+++ b/ironmq/src/test/scala/akka/stream/alpakka/ironmq/scaladsl/IronMqConsumerSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/scala/akka/stream/alpakka/ironmq/scaladsl/IronMqProducerSpec.scala
+++ b/ironmq/src/test/scala/akka/stream/alpakka/ironmq/scaladsl/IronMqProducerSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/ironmq/src/test/scala/docs/scaladsl/IronMqDocsSpec.scala
+++ b/ironmq/src/test/scala/docs/scaladsl/IronMqDocsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsAckConnectorsTest.java
+++ b/jms/src/test/java/akka/stream/alpakka/jms/javadsl/JmsAckConnectorsTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/java/docs/javadsl/JmsSettingsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsSettingsTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/resources/application.conf
+++ b/jms/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsConnectionStatusSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsConnectionStatusSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsProducerRetrySpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsSharedServerSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsSharedServerSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/JmsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/impl/JmsMessageProducerSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/impl/JmsMessageProducerSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/impl/SoftReferenceCacheSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/impl/SoftReferenceCacheSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/CachedConnectionFactory.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/CachedConnectionFactory.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
+++ b/jms/src/test/scala/akka/stream/alpakka/jms/scaladsl/JmsAckConnectorsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsTxConnectorsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
+++ b/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/json-streaming/src/test/resources/application.conf
+++ b/json-streaming/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/json-streaming/src/test/scala/docs/scaladsl/JsonReaderTest.scala
+++ b/json-streaming/src/test/scala/docs/scaladsl/JsonReaderTest.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/KinesisTest.java
+++ b/kinesis/src/test/java/akka/stream/alpakka/kinesis/javadsl/KinesisTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/java/docs/javadsl/KclSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KclSnippets.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/java/docs/javadsl/KinesisFirehoseSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KinesisFirehoseSnippets.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/resources/application.conf
+++ b/kinesis/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/DefaultTestContext.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/DefaultTestContext.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisFlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisMock.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisMock.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSchedulerSourceSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSchedulerSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSourceSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/KinesisSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/ShardSettingsSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/ShardSettingsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesis/Valve.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesis/Valve.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseFlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseMock.scala
+++ b/kinesis/src/test/scala/akka/stream/alpakka/kinesisfirehose/KinesisFirehoseMock.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/docs/scaladsl/KclSnippets.scala
+++ b/kinesis/src/test/scala/docs/scaladsl/KclSnippets.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/docs/scaladsl/KinesisFirehoseSnippets.scala
+++ b/kinesis/src/test/scala/docs/scaladsl/KinesisFirehoseSnippets.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
+++ b/kinesis/src/test/scala/docs/scaladsl/KinesisSnippets.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kudu/src/test/java/docs/javadsl/KuduTableTest.java
+++ b/kudu/src/test/java/docs/javadsl/KuduTableTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/kudu/src/test/resources/application.conf
+++ b/kudu/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
+++ b/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mongodb/src/test/java/docs/javadsl/DomainObject.java
+++ b/mongodb/src/test/java/docs/javadsl/DomainObject.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mongodb/src/test/java/docs/javadsl/Number.java
+++ b/mongodb/src/test/java/docs/javadsl/Number.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mongodb/src/test/resources/application.conf
+++ b/mongodb/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt-streaming/src/test/resources/application.conf
+++ b/mqtt-streaming/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/MqttFrameStageSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/MqttFrameStageSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/QueueOfferStateSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/QueueOfferStateSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestStateSpec.scala
+++ b/mqtt-streaming/src/test/scala/akka/stream/alpakka/mqtt/streaming/impl/RequestStateSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttActorSystemsSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttActorSystemsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttCodecSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttCodecSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt/src/test/resources/application.conf
+++ b/mqtt/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/mqtt/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt/src/test/scala/docs/scaladsl/MqttSinkSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttSinkSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/mqtt/src/test/scala/docs/scaladsl/MqttSpecBase.scala
+++ b/mqtt/src/test/scala/docs/scaladsl/MqttSpecBase.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/orientdb/src/test/resources/application.conf
+++ b/orientdb/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.testkit.TestEventListener", "akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala
+++ b/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/java/akka/stream/alpakka/pravega/PravegaAkkaTestCaseSupport.java
+++ b/pravega/src/test/java/akka/stream/alpakka/pravega/PravegaAkkaTestCaseSupport.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/java/akka/stream/alpakka/pravega/PravegaGraphTestCase.java
+++ b/pravega/src/test/java/akka/stream/alpakka/pravega/PravegaGraphTestCase.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/java/akka/stream/alpakka/pravega/PravegaKVTableTestCase.java
+++ b/pravega/src/test/java/akka/stream/alpakka/pravega/PravegaKVTableTestCase.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/java/docs/javadsl/PravegaBaseTestCase.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaBaseTestCase.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/java/docs/javadsl/PravegaReadWriteDocs.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaReadWriteDocs.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/java/docs/javadsl/PravegaSettingsTestCase.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaSettingsTestCase.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/resources/application.conf
+++ b/pravega/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka.alpakka.pravega {
   defaults.client-config {
     #controller-uri = "tcp://localhost:9090"

--- a/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaBaseSpec.scala
+++ b/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaBaseSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaGraphSpec.scala
+++ b/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaGraphSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaKVTableSpec.scala
+++ b/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaKVTableSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaStreamAndTableSpec.scala
+++ b/pravega/src/test/scala/akka/stream/alpakka/pravega/PravegaStreamAndTableSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/scala/docs/scaladsl/Model.scala
+++ b/pravega/src/test/scala/docs/scaladsl/Model.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/scala/docs/scaladsl/PravegaReadWriteDocs.scala
+++ b/pravega/src/test/scala/docs/scaladsl/PravegaReadWriteDocs.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/scala/docs/scaladsl/PravegaSettingsSpec.scala
+++ b/pravega/src/test/scala/docs/scaladsl/PravegaSettingsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/pravega/src/test/scala/docs/scaladsl/Serializers.scala
+++ b/pravega/src/test/scala/docs/scaladsl/Serializers.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/reference/src/test/java/docs/javadsl/ReferenceTest.java
+++ b/reference/src/test/java/docs/javadsl/ReferenceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/reference/src/test/resources/application.conf
+++ b/reference/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/reference/src/test/scala/docs/scaladsl/ReferenceSpec.scala
+++ b/reference/src/test/scala/docs/scaladsl/ReferenceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/java/docs/javadsl/S3Test.java
+++ b/s3/src/test/java/docs/javadsl/S3Test.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/resources/application.conf
+++ b/s3/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.testkit.TestEventListener", "akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/s3/src/test/scala/akka/stream/alpakka/s3/MinioContainer.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/MinioContainer.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/MinioS3Test.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/MinioS3Test.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/S3ExceptionSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/S3ExceptionSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/S3SettingsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/DiskBufferSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/DiskBufferSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/HttpRequestsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MarshallingSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/MemoryBufferSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/MemoryBufferSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3HeadersSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3HeadersSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/S3StreamSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/SplitAfterSizeSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/CanonicalRequestSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/CanonicalRequestSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SignerSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SigningKeySpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SigningKeySpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SplitAfterSizeWithContextSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/SplitAfterSizeWithContextSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/StreamUtilsSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/StreamUtilsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/authSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/impl/auth/authSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ClientIntegrationSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3ExtSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3IntegrationSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SlowMinioIntegrationSpec.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3SlowMinioIntegrationSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
+++ b/s3/src/test/scala/akka/stream/alpakka/s3/scaladsl/S3WireMockBase.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/s3/src/test/scala/docs/scaladsl/S3SourceSpec.scala
+++ b/s3/src/test/scala/docs/scaladsl/S3SourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
+++ b/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/simple-codecs/src/test/resources/application.conf
+++ b/simple-codecs/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/simple-codecs/src/test/scala/docs/scaladsl/RecordIOFramingSpec.scala
+++ b/simple-codecs/src/test/scala/docs/scaladsl/RecordIOFramingSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/slick/src/test/java/docs/javadsl/DocSnippetFlow.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetFlow.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/slick/src/test/java/docs/javadsl/DocSnippetFlowWithPassThrough.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetFlowWithPassThrough.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/slick/src/test/java/docs/javadsl/DocSnippetSink.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetSink.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/slick/src/test/java/docs/javadsl/DocSnippetSource.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetSource.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/slick/src/test/java/docs/javadsl/SlickTest.java
+++ b/slick/src/test/java/docs/javadsl/SlickTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/slick/src/test/java/docs/javadsl/User.java
+++ b/slick/src/test/java/docs/javadsl/User.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/slick/src/test/resources/application.conf
+++ b/slick/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/slick/src/test/scala/docs/scaladsl/DocSnippets.scala
+++ b/slick/src/test/scala/docs/scaladsl/DocSnippets.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
+++ b/slick/src/test/scala/docs/scaladsl/SlickSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sns/src/test/java/docs/javadsl/SnsPublisherTest.java
+++ b/sns/src/test/java/docs/javadsl/SnsPublisherTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sns/src/test/resources/application.conf
+++ b/sns/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/sns/src/test/scala/akka/stream/alpakka/sns/DefaultTestContext.scala
+++ b/sns/src/test/scala/akka/stream/alpakka/sns/DefaultTestContext.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sns/src/test/scala/akka/stream/alpakka/sns/IntegrationTestContext.scala
+++ b/sns/src/test/scala/akka/stream/alpakka/sns/IntegrationTestContext.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sns/src/test/scala/akka/stream/alpakka/sns/SnsPublishMockingSpec.scala
+++ b/sns/src/test/scala/akka/stream/alpakka/sns/SnsPublishMockingSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sns/src/test/scala/docs/scaladsl/SnsPublisherSpec.scala
+++ b/sns/src/test/scala/docs/scaladsl/SnsPublisherSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/solr/src/test/java/docs/javadsl/SolrTest.java
+++ b/solr/src/test/java/docs/javadsl/SolrTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/solr/src/test/resources/application.conf
+++ b/solr/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka.stream.akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
+++ b/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/spring-web/src/test/java/docs/javadsl/DemoApplication.java
+++ b/spring-web/src/test/java/docs/javadsl/DemoApplication.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/spring-web/src/test/java/docs/javadsl/SampleController.java
+++ b/spring-web/src/test/java/docs/javadsl/SampleController.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/spring-web/src/test/resources/application.conf
+++ b/spring-web/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java
+++ b/sqs/src/test/java/akka/stream/alpakka/sqs/javadsl/BaseSqsTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/java/docs/javadsl/SqsAckTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsAckTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/resources/application.conf
+++ b/sqs/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/SqsModelSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/SqsModelSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/DefaultTestContext.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/MessageAttributeNameSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/MessageAttributeNameSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsPublishSinkSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
+++ b/sqs/src/test/scala/akka/stream/alpakka/sqs/scaladsl/SqsSourceMockSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sse/src/test/java/docs/javadsl/EventSourceTest.java
+++ b/sse/src/test/java/docs/javadsl/EventSourceTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/sse/src/test/resources/application.conf
+++ b/sse/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/sse/src/test/scala/docs/scaladsl/EventSourceSpec.scala
+++ b/sse/src/test/scala/docs/scaladsl/EventSourceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
+++ b/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/text/src/test/resources/application.conf
+++ b/text/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
+++ b/text/src/test/scala/akka/stream/alpakka/text/scaladsl/CharsetCodingFlowsSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
+++ b/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/udp/src/test/resources/application.conf
+++ b/udp/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
+++ b/udp/src/test/scala/docs/scaladsl/UdpSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
+++ b/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/unix-domain-socket/src/test/resources/application.conf
+++ b/unix-domain-socket/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
+++ b/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/xml/src/test/java/docs/javadsl/XmlHelper.java
+++ b/xml/src/test/java/docs/javadsl/XmlHelper.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/xml/src/test/java/docs/javadsl/XmlParsingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlParsingTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/xml/src/test/java/docs/javadsl/XmlWritingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlWritingTest.java
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/xml/src/test/resources/application.conf
+++ b/xml/src/test/resources/application.conf
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/xml/src/test/scala/docs/scaladsl/XmlCoalesceSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlCoalesceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlProcessingSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/xml/src/test/scala/docs/scaladsl/XmlSubsliceSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlSubsliceSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/xml/src/test/scala/docs/scaladsl/XmlSubtreeSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlSubtreeSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 

--- a/xml/src/test/scala/docs/scaladsl/XmlWritingSpec.scala
+++ b/xml/src/test/scala/docs/scaladsl/XmlWritingSpec.scala
@@ -1,4 +1,13 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+/*
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 


### PR DESCRIPTION
* the issue solution tries to create 2 settings confs, each with different license text - 1 with full header for scala/java one 1 with SPDX text for confs
* this doesn't work as the license text set for the 2nd (the SPDX one) overwrites the first
* this solution is messy but fixes the issue by setting headerLicense only once (the full header text) and ignoring this and using the SPDX text when dealing with conf headers