### PR TITLE
ftp CI tests: use ubuntu:squid docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,7 +238,7 @@ services:
     command: username:userpass:${FTP_USER_UID:-2000}:${FTP_USER_GID:-2000}
   squid:
     network_mode: host # required for route back to localhost
-    image: datadog/squid
+    image: ubuntu/squid
     volumes:
       - ./ftp/src/test/resources/squid.conf:/etc/squid/squid.conf
   pravega:


### PR DESCRIPTION
* relates to https://github.com/apache/incubator-pekko-connectors/issues/42
* The datadog/squid image was deleted
* FTP tests passed in https://github.com/apache/incubator-pekko-connectors/actions/runs/4394330140 with this change (in another PR that is not for merging, just for testing)
* failed before this change - https://github.com/apache/incubator-pekko-connectors/actions/runs/4394281553