### PR TITLE
increase timeouts on flaky tests

### DIFF
--- a/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
@@ -53,8 +53,11 @@ class MongoSinkSpec
 
   implicit val system = ActorSystem()
 
-  override protected def beforeAll(): Unit =
+  override protected def beforeAll(): Unit = {
+    implicit val patienceConfig =
+      PatienceConfig(timeout = 2.seconds, interval = 100.millis)
     Source.fromPublisher(db.drop()).runWith(Sink.headOption).futureValue
+  }
 
   private val client = MongoClients.create(s"mongodb://localhost:27017")
   private val db = client.getDatabase("MongoSinkSpec").withCodecRegistry(codecRegistry)

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -2037,7 +2037,7 @@ class MqttSessionSpec
       connect2Received.future.futureValue shouldBe Done
 
       serverConnection2.offer(Command(connAck))
-      client2.expectMsg(connAckBytes)
+      client2.expectMsg(6.seconds, connAckBytes)
 
       client2Connection.offer(subscribeBytes)
 


### PR DESCRIPTION
* google-pub-sub has a separate issue
* this covers https://github.com/apache/incubator-pekko-connectors/issues/46
* plus one recent failure in the mongo tests - https://github.com/apache/incubator-pekko-connectors/actions/runs/4416039025/jobs/7741174718