### PR TITLE
Use Pekko Java/Scala converters to remove warnings

### DIFF
--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/AmqpConnectionProvider.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/AmqpConnectionProvider.scala
@@ -23,7 +23,7 @@ import javax.net.ssl.{ SSLContext, TrustManager }
 
 import scala.annotation.tailrec
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Only for internal implementations
@@ -131,7 +131,7 @@ final class AmqpDetailsConnectionProvider private (
     copy(connectionName = Option(name))
 
   override def get: Connection = {
-    import scala.collection.JavaConverters._
+    import org.apache.pekko.util.ccompat.JavaConverters._
     val factory = new ConnectionFactory
     credentials.foreach { credentials =>
       factory.setUsername(credentials.username)
@@ -339,7 +339,7 @@ final class AmqpConnectionFactoryConnectionProvider private (val factory: Connec
     copy(hostAndPorts = hostAndPorts.asScala.map(_.toScala).toIndexedSeq)
 
   override def get: Connection = {
-    import scala.collection.JavaConverters._
+    import org.apache.pekko.util.ccompat.JavaConverters._
     factory.newConnection(hostAndPortList.map(hp => new Address(hp._1, hp._2)).asJava)
   }
 

--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/AmqpConnectorSettings.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/AmqpConnectorSettings.scala
@@ -17,7 +17,7 @@ import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.util.JavaDurationConverters._
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration._
 

--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpConnectorLogic.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpConnectorLogic.scala
@@ -42,7 +42,7 @@ private trait AmqpConnectorLogic { this: GraphStageLogic =>
       connection.addShutdownListener(shutdownListener)
       channel.addShutdownListener(shutdownListener)
 
-      import scala.collection.JavaConverters._
+      import org.apache.pekko.util.ccompat.JavaConverters._
 
       settings.declarations.foreach {
         case d: QueueDeclaration =>

--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpSourceStage.scala
@@ -60,7 +60,7 @@ private[amqp] final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSi
       private var unackedMessages = 0
 
       override def whenConnected(): Unit = {
-        import scala.collection.JavaConverters._
+        import org.apache.pekko.util.ccompat.JavaConverters._
         channel.basicQos(bufferSize)
         val consumerCallback = getAsyncCallback(handleDelivery)
 

--- a/azure-storage-queue/src/main/scala/org/apache/pekko/stream/connectors/azure/storagequeue/impl/AzureQueueSourceStage.scala
+++ b/azure-storage-queue/src/main/scala/org/apache/pekko/stream/connectors/azure/storagequeue/impl/AzureQueueSourceStage.scala
@@ -45,7 +45,7 @@ import scala.collection.mutable.Queue
       retrieveMessages()
 
     def retrieveMessages(): Unit = {
-      import scala.collection.JavaConverters._
+      import org.apache.pekko.util.ccompat.JavaConverters._
       val res = cloudQueueBuilt
         .retrieveMessages(settings.batchSize, settings.initialVisibilityTimeout, null, null)
         .asScala

--- a/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
+++ b/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
@@ -25,7 +25,7 @@ import com.microsoft.azure.storage._
 import com.microsoft.azure.storage.queue._
 import org.scalatest._
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.util.Properties

--- a/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/CassandraMetricsRegistry.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/CassandraMetricsRegistry.scala
@@ -18,7 +18,7 @@ import pekko.actor.{ ClassicActorSystemProvider, ExtendedActorSystem, Extension,
 import pekko.annotation.InternalApi
 import com.codahale.metrics.MetricRegistry
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Retrieves Cassandra metrics registry for an actor system

--- a/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/javadsl/CassandraSession.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/javadsl/CassandraSession.scala
@@ -19,7 +19,7 @@ import java.util.concurrent.{ CompletionStage, Executor }
 import java.util.function.{ Function => JFunction }
 
 import scala.annotation.varargs
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionContext

--- a/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraFlow.scala
@@ -20,7 +20,7 @@ import pekko.stream.connectors.cassandra.CassandraWriteSettings
 import pekko.stream.scaladsl.{ Flow, FlowWithContext }
 import com.datastax.oss.driver.api.core.cql.{ BatchStatement, BoundStatement, PreparedStatement }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 
 /**

--- a/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraSessionRegistry.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraSessionRegistry.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.stream.connectors.cassandra.scaladsl
 
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import org.apache.pekko

--- a/cassandra/src/test/scala/docs/javadsl/CassandraSessionSpec.scala
+++ b/cassandra/src/test/scala/docs/javadsl/CassandraSessionSpec.scala
@@ -29,7 +29,7 @@ import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import pekko.stream.testkit.scaladsl.TestSink
 import com.datastax.oss.driver.api.core.cql.Row
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._

--- a/cassandra/src/test/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraLifecycle.scala
+++ b/cassandra/src/test/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraLifecycle.scala
@@ -23,7 +23,7 @@ import com.datastax.oss.driver.api.core.cql._
 import org.scalatest._
 import org.scalatest.concurrent.{ PatienceConfiguration, ScalaFutures }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }

--- a/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/model.scala
+++ b/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/model.scala
@@ -23,7 +23,7 @@ import com.couchbase.client.java.env.CouchbaseEnvironment
 import com.couchbase.client.java.{ PersistTo, ReplicateTo }
 import com.typesafe.config.Config
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.compat.java8.FutureConverters._

--- a/couchbase/src/test/scala/org/apache/pekko/stream/connectors/couchbase/testing/CouchbaseSupport.scala
+++ b/couchbase/src/test/scala/org/apache/pekko/stream/connectors/couchbase/testing/CouchbaseSupport.scala
@@ -27,7 +27,7 @@ import com.couchbase.client.java.document.{ BinaryDocument, JsonDocument, RawJso
 import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._

--- a/dynamodb/src/test/scala/org/apache/pekko/stream/connectors/dynamodb/ItemSpec.scala
+++ b/dynamodb/src/test/scala/org/apache/pekko/stream/connectors/dynamodb/ItemSpec.scala
@@ -29,7 +29,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.TableStatus
 
 import scala.annotation.nowarn
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 class ItemSpec extends TestKit(ActorSystem("ItemSpec")) with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {

--- a/dynamodb/src/test/scala/org/apache/pekko/stream/connectors/dynamodb/TableSpec.scala
+++ b/dynamodb/src/test/scala/org/apache/pekko/stream/connectors/dynamodb/TableSpec.scala
@@ -25,7 +25,7 @@ import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCred
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpecLike
 

--- a/dynamodb/src/test/scala/org/apache/pekko/stream/connectors/dynamodb/TestOps.scala
+++ b/dynamodb/src/test/scala/org/apache/pekko/stream/connectors/dynamodb/TestOps.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.stream.connectors.dynamodb
 
 import software.amazon.awssdk.services.dynamodb.model._
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 trait TestOps {
 

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/ElasticsearchConnectionSettings.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/ElasticsearchConnectionSettings.scala
@@ -19,7 +19,7 @@ import pekko.http.scaladsl.model.HttpHeader
 import pekko.http.scaladsl.model.HttpHeader.ParsingResult
 import pekko.japi.Util
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import javax.net.ssl.SSLContext
 import scala.compat.java8.OptionConverters
 

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/WriteMessage.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/WriteMessage.scala
@@ -17,7 +17,7 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 /**

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -19,7 +19,7 @@ import pekko.annotation.ApiMayChange
 import pekko.stream.connectors.elasticsearch.{ scaladsl, _ }
 import com.fasterxml.jackson.databind.ObjectMapper
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Java API to create Elasticsearch flows.

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/javadsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/javadsl/ElasticsearchSource.scala
@@ -23,7 +23,7 @@ import pekko.stream.{ Attributes, Materializer }
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.{ ArrayNode, NumericNode }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 /**

--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/javadsl/LogRotatorSink.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/javadsl/LogRotatorSink.scala
@@ -25,7 +25,7 @@ import pekko.stream.javadsl.Sink
 import pekko.util.ByteString
 import pekko.japi.function
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 
 import scala.compat.java8.FutureConverters._

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -30,7 +30,7 @@ import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.{ ExecutionContext, Future }
 
 class ArchiveSpec

--- a/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
@@ -32,7 +32,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.annotation.nowarn
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/SftpOperations.scala
@@ -28,7 +28,7 @@ import net.schmizz.sshj.userauth.password.{ PasswordFinder, PasswordUtils, Resou
 import net.schmizz.sshj.xfer.FilePermission
 import org.apache.commons.net.DefaultSocketFactory
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.util.{ Failure, Try }
 

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/ProtobufConverters.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/ProtobufConverters.scala
@@ -18,7 +18,7 @@ import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions
 import com.google.cloud.bigquery.storage.v1.stream.ReadSession
 import scalapb.UnknownFieldSet
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Internal API

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/impl/ArrowSource.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/impl/ArrowSource.scala
@@ -28,7 +28,7 @@ import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 object ArrowSource {
 

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryArrowStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryArrowStorage.scala
@@ -22,7 +22,7 @@ import pekko.stream.connectors.googlecloud.bigquery.storage.{ scaladsl => scstor
 import com.google.cloud.bigquery.storage.v1.arrow.{ ArrowRecordBatch, ArrowSchema }
 
 import java.util.concurrent.CompletionStage
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters.FutureOps
 
 /**

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryAvroStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryAvroStorage.scala
@@ -21,7 +21,7 @@ import com.google.cloud.bigquery.storage.v1.avro.{ AvroRows, AvroSchema }
 import com.google.cloud.bigquery.storage.v1.stream.ReadSession.TableReadOptions
 
 import java.util.concurrent.CompletionStage
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters.FutureOps
 
 /**

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorage.scala
@@ -28,7 +28,7 @@ import com.google.cloud.bigquery.storage.v1.stream.ReadSession
 
 import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters.FutureOps
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Google BigQuery Storage Api Akka Stream operator factory.

--- a/google-cloud-bigquery-storage/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/AvroByteStringDecoder.scala
+++ b/google-cloud-bigquery-storage/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/AvroByteStringDecoder.scala
@@ -26,7 +26,7 @@ import org.apache.avro.io.DecoderFactory
 import java.util
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 class AvroByteStringDecoder(schema: Schema) extends FromByteStringUnmarshaller[java.util.List[BigQueryRecord]] {
 

--- a/google-cloud-bigquery-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/scaladsl/ArrowByteStringDecoder.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/scaladsl/ArrowByteStringDecoder.scala
@@ -28,7 +28,7 @@ import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 class ArrowByteStringDecoder(val schema: ArrowSchema) extends FromByteStringUnmarshaller[List[BigQueryRecord]] {
 

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/javadsl/BigQuery.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/javadsl/BigQuery.scala
@@ -44,7 +44,7 @@ import java.util.concurrent.CompletionStage
 import java.{ lang, util }
 
 import scala.annotation.nowarn
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.{ FiniteDuration, MILLISECONDS }

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/DatasetJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/DatasetJsonProtocol.scala
@@ -19,7 +19,7 @@ import pekko.stream.connectors.googlecloud.bigquery.scaladsl.spray.BigQueryRestJ
 import spray.json.{ JsonFormat, RootJsonFormat }
 
 import java.util
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/JobJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/JobJsonProtocol.scala
@@ -20,7 +20,7 @@ import spray.json.{ JsonFormat, RootJsonFormat }
 import java.util
 
 import scala.annotation.nowarn
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/QueryJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/QueryJsonProtocol.scala
@@ -26,7 +26,7 @@ import java.{ lang, util }
 
 import scala.annotation.nowarn
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.FiniteDuration

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/TableDataJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/TableDataJsonProtocol.scala
@@ -25,7 +25,7 @@ import java.{ lang, util }
 
 import scala.annotation.nowarn
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/TableJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/TableJsonProtocol.scala
@@ -25,7 +25,7 @@ import scala.annotation.nowarn
 import scala.annotation.varargs
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Table resource model

--- a/google-cloud-bigquery/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/A.scala
+++ b/google-cloud-bigquery/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/A.scala
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 
 import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime }
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 @JsonPropertyOrder(alphabetic = true)
 case class A(integer: Int, long: Long, float: Float, double: Double, string: String, boolean: Boolean, record: B) {

--- a/google-cloud-bigquery/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/EndToEndHelper.scala
+++ b/google-cloud-bigquery/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/EndToEndHelper.scala
@@ -14,7 +14,7 @@
 package org.apache.pekko.stream.connectors.googlecloud.bigquery.e2e.javadsl
 
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.e2e.scaladsl
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 abstract class EndToEndHelper extends scaladsl.EndToEndHelper {
 

--- a/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/javadsl/GooglePubSub.scala
@@ -23,7 +23,7 @@ import pekko.{ Done, NotUsed }
 import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Java DSL for Google Pub/Sub

--- a/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/model.scala
+++ b/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/model.scala
@@ -22,7 +22,7 @@ import pekko.stream.connectors.google.auth.ServiceAccountCredentials
 
 import scala.annotation.nowarn
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * @param projectId (deprecated) the project Id in the google account

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/FailedUpload.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/FailedUpload.scala
@@ -14,7 +14,7 @@
 package org.apache.pekko.stream.connectors.googlecloud.storage
 
 import scala.collection.immutable.Seq
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 final class FailedUpload private (
     val reasons: Seq[Throwable]) extends Exception(reasons.map(_.getMessage).mkString(", ")) {

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/StorageObject.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/StorageObject.scala
@@ -19,7 +19,7 @@ import java.util.Optional
 import org.apache.pekko
 import pekko.http.scaladsl.model.ContentType
 import scala.compat.java8.OptionConverters._
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Represents an object within Google Cloud Storage.

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/javadsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/javadsl/GCStorage.scala
@@ -27,7 +27,7 @@ import pekko.stream.{ Attributes, Materializer }
 import pekko.util.ByteString
 import pekko.{ Done, NotUsed }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCSExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCSExtSpec.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 class GCSExtSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCSExt" should "reuse application config from actor system" in {

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCSSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCSSettingsSpec.scala
@@ -18,7 +18,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 class GCSSettingsSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCSSettings" should "create settings from application config" in {

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageExtSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.annotation.nowarn
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 class GCStorageExtSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCStorageExt" should "reuse application config from actor system" in {

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageSettingsSpec.scala
@@ -19,7 +19,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.annotation.nowarn
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 class GCStorageSettingsSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCStorageSettings" should "create settings from application config" in {

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/ServiceAccountCredentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/ServiceAccountCredentials.scala
@@ -23,7 +23,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.json.{ JsonParser, RootJsonFormat }
 
 import java.time.Clock
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 import scala.io.Source
 

--- a/hbase/src/main/scala/org/apache/pekko/stream/connectors/hbase/HTableSettings.scala
+++ b/hbase/src/main/scala/org/apache/pekko/stream/connectors/hbase/HTableSettings.scala
@@ -18,7 +18,7 @@ import org.apache.hadoop.hbase.TableName
 import org.apache.hadoop.hbase.client.Mutation
 
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FunctionConverters._
 
 final class HTableSettings[T] private (val conf: Configuration,

--- a/hdfs/src/test/scala/org/apache/pekko/stream/connectors/hdfs/util/TestUtils.scala
+++ b/hdfs/src/test/scala/org/apache/pekko/stream/connectors/hdfs/util/TestUtils.scala
@@ -187,7 +187,7 @@ object JavaTestUtils extends TestUtils {
 
   import org.junit.Assert._
 
-  import scala.collection.JavaConverters._
+  import org.apache.pekko.util.ccompat.JavaConverters._
 
   val books: util.List[ByteString] = ScalaTestUtils.books.asJava
 

--- a/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/AlpakkaResultMapperHelper.scala
+++ b/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/AlpakkaResultMapperHelper.scala
@@ -26,7 +26,7 @@ import org.apache.pekko.annotation.InternalApi
 import org.influxdb.InfluxDBMapperException
 import org.influxdb.dto.Point
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Internal API.

--- a/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/InfluxDbSourceStage.scala
+++ b/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/InfluxDbSourceStage.scala
@@ -21,7 +21,7 @@ import pekko.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
 import org.influxdb.{ InfluxDB, InfluxDBException }
 import org.influxdb.dto.{ Query, QueryResult }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * INTERNAL API

--- a/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/javadsl/InfluxDbFlow.scala
+++ b/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/javadsl/InfluxDbFlow.scala
@@ -22,7 +22,7 @@ import pekko.stream.javadsl.Flow
 import pekko.stream.connectors.influxdb.scaladsl
 import org.influxdb.dto.Point
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * API may change.

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
@@ -27,7 +27,7 @@ import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.testkit.TestKit
 import pekko.stream.scaladsl.Sink
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import docs.javadsl.TestUtils._
 import docs.javadsl.TestConstants.{ INFLUXDB_URL, PASSWORD, USERNAME }
 import org.scalatest.matchers.must.Matchers

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/JmsMessages.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/JmsMessages.scala
@@ -19,7 +19,7 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.connectors.jms.impl.JmsMessageReader._
 import pekko.util.ByteString
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 /**

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsMessageReader.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsMessageReader.scala
@@ -20,7 +20,7 @@ import pekko.annotation.InternalApi
 import pekko.stream.connectors.jms._
 import pekko.util.ByteString
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 @InternalApi
 private[jms] object JmsMessageReader {

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/javadsl/JmsConsumer.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/javadsl/JmsConsumer.scala
@@ -19,7 +19,7 @@ import pekko.NotUsed
 import pekko.stream.connectors.jms._
 import pekko.stream.javadsl.Source
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Factory methods to create JMS consumers.

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/javadsl/JmsProducer.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/javadsl/JmsProducer.scala
@@ -22,7 +22,7 @@ import pekko.stream.scaladsl.{ Flow, Keep }
 import pekko.util.ByteString
 import pekko.{ Done, NotUsed }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters
 
 /**

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/scaladsl/JmsConsumer.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/scaladsl/JmsConsumer.scala
@@ -20,7 +20,7 @@ import pekko.stream.connectors.jms.impl._
 import pekko.stream.scaladsl.Source
 import javax.jms
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Factory methods to create JMS consumers.

--- a/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
@@ -34,7 +34,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.collection.mutable
 import scala.concurrent.Future

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSourceStage.scala
@@ -25,7 +25,7 @@ import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.services.kinesis.model._
 
 import scala.collection.mutable
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.util.{ Failure, Success, Try }
 
 import scala.compat.java8.FutureConverters._

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/ShardProcessor.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/ShardProcessor.scala
@@ -24,7 +24,7 @@ import software.amazon.kinesis.lifecycle.events._
 import software.amazon.kinesis.processor.{ RecordProcessorCheckpointer, ShardRecordProcessor }
 import software.amazon.kinesis.retrieval.KinesisClientRecord
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 @InternalApi
 private[kinesis] class ShardProcessor(

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/javadsl/KinesisSource.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/javadsl/KinesisSource.scala
@@ -20,7 +20,7 @@ import pekko.stream.javadsl.Source
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.services.kinesis.model.Record
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 object KinesisSource {
 

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/scaladsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/scaladsl/KinesisFlow.scala
@@ -32,7 +32,7 @@ import software.amazon.awssdk.services.kinesis.model.{
   PutRecordsResultEntry
 }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Queue
 import scala.concurrent.duration._
 import scala.compat.java8.FutureConverters._

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesisfirehose/scaladsl/KinesisFirehoseFlow.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesisfirehose/scaladsl/KinesisFirehoseFlow.scala
@@ -23,7 +23,7 @@ import pekko.stream.scaladsl.Flow
 import software.amazon.awssdk.services.firehose.FirehoseAsyncClient
 import software.amazon.awssdk.services.firehose.model.{ PutRecordBatchRequest, PutRecordBatchResponseEntry, Record }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Queue
 import scala.concurrent.duration._
 

--- a/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisFlowSpec.scala
@@ -32,7 +32,7 @@ import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kinesis.model._
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with LogCapturing {
 

--- a/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisSchedulerSourceSpec.scala
+++ b/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisSchedulerSourceSpec.scala
@@ -47,7 +47,7 @@ import software.amazon.kinesis.processor.{
 import software.amazon.kinesis.retrieval.KinesisClientRecord
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random

--- a/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesisfirehose/KinesisFirehoseFlowSpec.scala
+++ b/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesisfirehose/KinesisFirehoseFlowSpec.scala
@@ -32,7 +32,7 @@ import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.firehose.model._
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 class KinesisFirehoseFlowSpec extends AnyWordSpec with Matchers with KinesisFirehoseMock with LogCapturing {
 

--- a/kudu/src/main/scala/org/apache/pekko/stream/connectors/kudu/impl/KuduFlowStage.scala
+++ b/kudu/src/main/scala/org/apache/pekko/stream/connectors/kudu/impl/KuduFlowStage.scala
@@ -22,7 +22,7 @@ import org.apache.kudu.Schema
 import org.apache.kudu.Type._
 import org.apache.kudu.client.{ KuduClient, KuduTable, PartialRow }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.util.control.NonFatal
 
 /**

--- a/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
+++ b/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
@@ -26,7 +26,7 @@ import org.apache.kudu.{ ColumnSchema, Schema, Type }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers

--- a/mongodb/src/main/scala/org/apache/pekko/stream/connectors/mongodb/javadsl/MongoFlow.scala
+++ b/mongodb/src/main/scala/org/apache/pekko/stream/connectors/mongodb/javadsl/MongoFlow.scala
@@ -29,7 +29,7 @@ import com.mongodb.client.result.{ DeleteResult, UpdateResult }
 import com.mongodb.reactivestreams.client.MongoCollection
 import org.bson.conversions.Bson
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 object MongoFlow {
 

--- a/mongodb/src/main/scala/org/apache/pekko/stream/connectors/mongodb/scaladsl/MongoFlow.scala
+++ b/mongodb/src/main/scala/org/apache/pekko/stream/connectors/mongodb/scaladsl/MongoFlow.scala
@@ -23,7 +23,7 @@ import com.mongodb.client.result.{ DeleteResult, UpdateResult }
 import com.mongodb.reactivestreams.client.MongoCollection
 import org.bson.conversions.Bson
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 object MongoFlow {
 

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
@@ -29,7 +29,7 @@ import org.mongodb.scala.bson.codecs.Macros._
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
@@ -25,7 +25,7 @@ import org.bson.Document
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.concurrent.duration._

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/model.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/model.scala
@@ -27,7 +27,7 @@ import pekko.util.{ ByteIterator, ByteString, ByteStringBuilder }
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.{ ExecutionContext, Promise }
 

--- a/mqtt/src/main/scala/org/apache/pekko/stream/connectors/mqtt/settings.scala
+++ b/mqtt/src/main/scala/org/apache/pekko/stream/connectors/mqtt/settings.scala
@@ -17,7 +17,7 @@ import org.apache.pekko
 import pekko.util.JavaDurationConverters._
 import org.eclipse.paho.client.mqttv3.{ MqttClientPersistence, MqttConnectOptions }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.collection.immutable.Map
 import scala.concurrent.duration.{ FiniteDuration, _ }

--- a/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/impl/OrientDbSourceStage.scala
+++ b/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/impl/OrientDbSourceStage.scala
@@ -24,7 +24,7 @@ import com.orientechnologies.orient.`object`.db.OObjectDatabaseTx
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * INTERNAL API

--- a/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/javadsl/OrientDbFlow.scala
+++ b/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/javadsl/OrientDbFlow.scala
@@ -19,7 +19,7 @@ import pekko.stream.connectors.orientdb._
 import pekko.stream.javadsl.Flow
 import com.orientechnologies.orient.core.record.impl.ODocument
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Java API.

--- a/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/model.scala
+++ b/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/model.scala
@@ -20,7 +20,7 @@ import pekko.annotation.InternalApi
 import pekko.util.ByteString
 
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.util.{ Success, Try }
 

--- a/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/testkit/MessageFactory.scala
+++ b/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/testkit/MessageFactory.scala
@@ -19,7 +19,7 @@ import pekko.stream.connectors.reference.{ ReferenceReadResult, ReferenceWriteMe
 import pekko.util.ByteString
 
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.util.{ Failure, Success, Try }
 
 @ApiMayChange

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/S3Headers.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/S3Headers.scala
@@ -23,7 +23,7 @@ import pekko.stream.connectors.s3.headers.{ CannedAcl, ServerSideEncryption, Sto
 import pekko.stream.connectors.s3.impl.S3Request
 
 import scala.collection.immutable.Seq
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 final class MetaHeaders private (val metaHeaders: Map[String, String]) {
 

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
@@ -31,7 +31,7 @@ import pekko.stream.connectors.s3.impl._
 import pekko.stream.javadsl.{ RunnableGraph, Sink, Source }
 import pekko.util.ByteString
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
 

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/model.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/model.scala
@@ -23,7 +23,7 @@ import pekko.stream.connectors.s3.AccessStyle.PathAccessStyle
 import scala.annotation.nowarn
 import scala.collection.immutable.Seq
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 final class MultipartUpload private (val bucket: String, val key: String, val uploadId: String) {

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3ExtSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3ExtSpec.scala
@@ -21,7 +21,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 class S3ExtSpec extends AnyFlatSpecLike with Matchers {
   it should "reuse application config from actor system" in {

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
@@ -40,7 +40,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 trait S3IntegrationSpec
     extends AnyFlatSpecLike

--- a/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/SolrMessages.scala
+++ b/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/SolrMessages.scala
@@ -17,7 +17,7 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 object WriteMessage {
   def createUpsertMessage[T](source: T): WriteMessage[T, NotUsed] =

--- a/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/impl/SolrFlowStage.scala
+++ b/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/impl/SolrFlowStage.scala
@@ -29,7 +29,7 @@ import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Internal API

--- a/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/javadsl/SolrFlow.scala
+++ b/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/javadsl/SolrFlow.scala
@@ -23,7 +23,7 @@ import pekko.stream.scaladsl.Flow
 import org.apache.solr.client.solrj.SolrClient
 import org.apache.solr.common.SolrInputDocument
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 
 /**

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/SqsSourceSettings.scala
@@ -18,7 +18,7 @@ import java.time.temporal.ChronoUnit
 import software.amazon.awssdk.services.sqs.model
 
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 
 final class SqsSourceSettings private (

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/javadsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/javadsl/SqsPublishFlow.scala
@@ -28,7 +28,7 @@ import pekko.stream.scaladsl.{ Flow => SFlow }
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Java API to create SQS flows.

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/javadsl/SqsPublishSink.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/javadsl/SqsPublishSink.scala
@@ -23,7 +23,7 @@ import pekko.stream.scaladsl.{ Flow, Keep }
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters.FutureOps
 
 /**

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsAckFlow.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsAckFlow.scala
@@ -28,7 +28,7 @@ import pekko.stream.scaladsl.{ Flow, GraphDSL, Merge, Partition }
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsPublishFlow.scala
@@ -24,7 +24,7 @@ import pekko.stream.scaladsl.{ Flow, Source }
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters._
 
 /**

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsSource.scala
@@ -22,7 +22,7 @@ import pekko.stream.scaladsl.{ Flow, Source }
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters._
 
 /**

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -32,7 +32,7 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 
 class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.{ Message, ReceiveMessageRequest, SendMessageRequest }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 
 class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -39,7 +39,7 @@ import software.amazon.awssdk.services.sqs.model.{
   SendMessageRequest
 }
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/sqs/src/test/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/DefaultTestContext.scala
@@ -32,7 +32,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
 //#init-client
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.Random
 

--- a/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/CapturingAppender.scala
+++ b/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/CapturingAppender.scala
@@ -99,7 +99,7 @@ import org.slf4j.LoggerFactory
    * Also clears the buffer..
    */
   def flush(sourceActorSystem: Option[String]): Unit = synchronized {
-    import scala.collection.JavaConverters._
+    import org.apache.pekko.util.ccompat.JavaConverters._
     val logbackLogger = getLogbackLogger(classOf[CapturingAppender].getName + "Delegate")
     val appenders = logbackLogger.iteratorForAppenders().asScala.filterNot(_ == this).toList
     for (event <- buffer; appender <- appenders) {

--- a/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
+++ b/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
@@ -53,7 +53,7 @@ class CharsetCodingFlowsDoc
       import pekko.stream.scaladsl.FileIO
 
       // #encoding
-      import scala.collection.JavaConverters._
+      import org.apache.pekko.util.ccompat.JavaConverters._
       val targetFile = Paths.get("target/outdata.txt")
       val strings = System.getProperties.asScala.map(p => p._1 + " -> " + p._2).toList
       // #encoding

--- a/text/src/test/scala/org/apache/pekko/stream/connectors/text/scaladsl/CharsetCodingFlowsSpec.scala
+++ b/text/src/test/scala/org/apache/pekko/stream/connectors/text/scaladsl/CharsetCodingFlowsSpec.scala
@@ -75,7 +75,7 @@ class CharsetCodingFlowsSpec
       import pekko.stream.scaladsl.FileIO
 
       // #encoding
-      import scala.collection.JavaConverters._
+      import org.apache.pekko.util.ccompat.JavaConverters._
       val targetFile = Paths.get("target/outdata.txt")
       val strings = System.getProperties.asScala.map(p => p._1 + " -> " + p._2).toList
       val stringSource: Source[String, _] = Source(strings)

--- a/xml/src/main/scala/org/apache/pekko/stream/connectors/xml/javadsl/XmlParsing.scala
+++ b/xml/src/main/scala/org/apache/pekko/stream/connectors/xml/javadsl/XmlParsing.scala
@@ -23,7 +23,7 @@ import org.w3c.dom.Element
 
 import java.util.function.Consumer
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 object XmlParsing {
 

--- a/xml/src/main/scala/org/apache/pekko/stream/connectors/xml/model.scala
+++ b/xml/src/main/scala/org/apache/pekko/stream/connectors/xml/model.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.stream.connectors.xml
 
 import java.util.Optional
 
-import scala.collection.JavaConverters._
+import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 /**


### PR DESCRIPTION
The usage of `import scala.collection.JavaConverters._` happens to create warnings when used under Scala 2.12. Thankfully pekko core happens to contain `org.apache.pekko.util.ccompat.JavaConverters._` which is designed precisely to avoid this issue (amongst others).

This should only be merged after https://github.com/apache/incubator-pekko-connectors/pull/65 is merged.