### PR TITLE
Update pekko snapshot version and cleanup imports

### DIFF
--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/AmqpConnectionProvider.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/AmqpConnectionProvider.scala
@@ -18,12 +18,12 @@ import java.util.concurrent.atomic.AtomicReference
 
 import org.apache.pekko
 import pekko.annotation.DoNotInherit
+import pekko.util.ccompat.JavaConverters._
 import com.rabbitmq.client.{ Address, Connection, ConnectionFactory, ExceptionHandler }
 import javax.net.ssl.{ SSLContext, TrustManager }
 
 import scala.annotation.tailrec
 import scala.collection.immutable
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Only for internal implementations
@@ -131,7 +131,7 @@ final class AmqpDetailsConnectionProvider private (
     copy(connectionName = Option(name))
 
   override def get: Connection = {
-    import org.apache.pekko.util.ccompat.JavaConverters._
+    import pekko.util.ccompat.JavaConverters._
     val factory = new ConnectionFactory
     credentials.foreach { credentials =>
       factory.setUsername(credentials.username)
@@ -339,7 +339,7 @@ final class AmqpConnectionFactoryConnectionProvider private (val factory: Connec
     copy(hostAndPorts = hostAndPorts.asScala.map(_.toScala).toIndexedSeq)
 
   override def get: Connection = {
-    import org.apache.pekko.util.ccompat.JavaConverters._
+    import pekko.util.ccompat.JavaConverters._
     factory.newConnection(hostAndPortList.map(hp => new Address(hp._1, hp._2)).asJava)
   }
 

--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/AmqpConnectorSettings.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/AmqpConnectorSettings.scala
@@ -15,9 +15,9 @@ package org.apache.pekko.stream.connectors.amqp
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.JavaDurationConverters._
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration._
 

--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpConnectorLogic.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpConnectorLogic.scala
@@ -42,7 +42,7 @@ private trait AmqpConnectorLogic { this: GraphStageLogic =>
       connection.addShutdownListener(shutdownListener)
       channel.addShutdownListener(shutdownListener)
 
-      import org.apache.pekko.util.ccompat.JavaConverters._
+      import pekko.util.ccompat.JavaConverters._
 
       settings.declarations.foreach {
         case d: QueueDeclaration =>

--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpSourceStage.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpSourceStage.scala
@@ -60,7 +60,7 @@ private[amqp] final class AmqpSourceStage(settings: AmqpSourceSettings, bufferSi
       private var unackedMessages = 0
 
       override def whenConnected(): Unit = {
-        import org.apache.pekko.util.ccompat.JavaConverters._
+        import pekko.util.ccompat.JavaConverters._
         channel.basicQos(bufferSize)
         val consumerCallback = getAsyncCallback(handleDelivery)
 

--- a/azure-storage-queue/src/main/scala/org/apache/pekko/stream/connectors/azure/storagequeue/impl/AzureQueueSourceStage.scala
+++ b/azure-storage-queue/src/main/scala/org/apache/pekko/stream/connectors/azure/storagequeue/impl/AzureQueueSourceStage.scala
@@ -45,7 +45,7 @@ import scala.collection.mutable.Queue
       retrieveMessages()
 
     def retrieveMessages(): Unit = {
-      import org.apache.pekko.util.ccompat.JavaConverters._
+      import pekko.util.ccompat.JavaConverters._
       val res = cloudQueueBuilt
         .retrieveMessages(settings.batchSize, settings.initialVisibilityTimeout, null, null)
         .asScala

--- a/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
+++ b/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
@@ -21,11 +21,11 @@ import pekko.stream.connectors.azure.storagequeue.scaladsl._
 import pekko.stream.scaladsl._
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import pekko.testkit._
+import pekko.util.ccompat.JavaConverters._
 import com.microsoft.azure.storage._
 import com.microsoft.azure.storage.queue._
 import org.scalatest._
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.util.Properties

--- a/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/CassandraMetricsRegistry.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/CassandraMetricsRegistry.scala
@@ -16,9 +16,8 @@ package org.apache.pekko.stream.connectors.cassandra
 import org.apache.pekko
 import pekko.actor.{ ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
 import pekko.annotation.InternalApi
+import pekko.util.ccompat.JavaConverters._
 import com.codahale.metrics.MetricRegistry
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Retrieves Cassandra metrics registry for an actor system

--- a/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/javadsl/CassandraSession.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/javadsl/CassandraSession.scala
@@ -19,7 +19,6 @@ import java.util.concurrent.{ CompletionStage, Executor }
 import java.util.function.{ Function => JFunction }
 
 import scala.annotation.varargs
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionContext
@@ -32,6 +31,7 @@ import pekko.event.LoggingAdapter
 import pekko.stream.connectors.cassandra.CassandraServerMetaData
 import pekko.stream.connectors.cassandra.{ scaladsl, CqlSessionProvider }
 import pekko.stream.javadsl.Source
+import pekko.util.ccompat.JavaConverters._
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.BatchStatement
 import com.datastax.oss.driver.api.core.cql.PreparedStatement

--- a/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraFlow.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraFlow.scala
@@ -18,9 +18,9 @@ import pekko.NotUsed
 import pekko.dispatch.ExecutionContexts
 import pekko.stream.connectors.cassandra.CassandraWriteSettings
 import pekko.stream.scaladsl.{ Flow, FlowWithContext }
+import pekko.util.ccompat.JavaConverters._
 import com.datastax.oss.driver.api.core.cql.{ BatchStatement, BoundStatement, PreparedStatement }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 
 /**

--- a/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraSessionRegistry.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraSessionRegistry.scala
@@ -15,7 +15,6 @@ package org.apache.pekko.stream.connectors.cassandra.scaladsl
 
 import java.util.concurrent.ConcurrentHashMap
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import org.apache.pekko
@@ -24,6 +23,7 @@ import pekko.actor.{ ClassicActorSystemProvider, ExtendedActorSystem, Extension,
 import pekko.annotation.InternalStableApi
 import pekko.event.Logging
 import pekko.stream.connectors.cassandra.{ CassandraSessionSettings, CqlSessionProvider }
+import pekko.util.ccompat.JavaConverters._
 import com.datastax.oss.driver.api.core.CqlSession
 import com.typesafe.config.Config
 

--- a/cassandra/src/test/scala/docs/javadsl/CassandraSessionSpec.scala
+++ b/cassandra/src/test/scala/docs/javadsl/CassandraSessionSpec.scala
@@ -27,9 +27,9 @@ import pekko.stream.connectors.cassandra.scaladsl.CassandraSpecBase
 import pekko.stream.javadsl.Sink
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import pekko.stream.testkit.scaladsl.TestSink
+import pekko.util.ccompat.JavaConverters._
 import com.datastax.oss.driver.api.core.cql.Row
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._

--- a/cassandra/src/test/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraLifecycle.scala
+++ b/cassandra/src/test/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraLifecycle.scala
@@ -19,11 +19,11 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.apache.pekko
 import pekko.Done
 import pekko.testkit.TestKitBase
+import pekko.util.ccompat.JavaConverters._
 import com.datastax.oss.driver.api.core.cql._
 import org.scalatest._
 import org.scalatest.concurrent.{ PatienceConfiguration, ScalaFutures }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }

--- a/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/model.scala
+++ b/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/model.scala
@@ -18,12 +18,12 @@ import java.util.concurrent.{ CompletionStage, TimeUnit }
 import org.apache.pekko
 import pekko.actor.{ ActorSystem, ClassicActorSystemProvider }
 import pekko.annotation.InternalApi
+import pekko.util.ccompat.JavaConverters._
 import com.couchbase.client.java.document.Document
 import com.couchbase.client.java.env.CouchbaseEnvironment
 import com.couchbase.client.java.{ PersistTo, ReplicateTo }
 import com.typesafe.config.Config
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.compat.java8.FutureConverters._

--- a/couchbase/src/test/scala/org/apache/pekko/stream/connectors/couchbase/testing/CouchbaseSupport.scala
+++ b/couchbase/src/test/scala/org/apache/pekko/stream/connectors/couchbase/testing/CouchbaseSupport.scala
@@ -19,6 +19,7 @@ import pekko.actor.ActorSystem
 import pekko.stream.connectors.couchbase.scaladsl.{ CouchbaseFlow, CouchbaseSession }
 import pekko.stream.connectors.couchbase.{ CouchbaseSessionSettings, CouchbaseWriteSettings }
 import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.util.ccompat.JavaConverters._
 import com.couchbase.client.deps.io.netty.buffer.Unpooled
 import com.couchbase.client.deps.io.netty.util.CharsetUtil
 import com.couchbase.client.java.ReplicateTo
@@ -27,7 +28,6 @@ import com.couchbase.client.java.document.{ BinaryDocument, JsonDocument, RawJso
 import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._

--- a/dynamodb/src/test/scala/org/apache/pekko/stream/connectors/dynamodb/ItemSpec.scala
+++ b/dynamodb/src/test/scala/org/apache/pekko/stream/connectors/dynamodb/ItemSpec.scala
@@ -19,6 +19,7 @@ import pekko.actor.ActorSystem
 import pekko.stream.connectors.dynamodb.scaladsl._
 import pekko.stream.scaladsl.Sink
 import pekko.testkit.TestKit
+import pekko.util.ccompat.JavaConverters._
 import com.github.pjfanning.pekkohttpspi.PekkoHttpClient
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers
@@ -29,7 +30,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.TableStatus
 
 import scala.annotation.nowarn
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 class ItemSpec extends TestKit(ActorSystem("ItemSpec")) with AsyncWordSpecLike with Matchers with BeforeAndAfterAll {

--- a/dynamodb/src/test/scala/org/apache/pekko/stream/connectors/dynamodb/TableSpec.scala
+++ b/dynamodb/src/test/scala/org/apache/pekko/stream/connectors/dynamodb/TableSpec.scala
@@ -19,13 +19,13 @@ import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.stream.connectors.dynamodb.scaladsl.DynamoDb
 import pekko.testkit.TestKit
+import pekko.util.ccompat.JavaConverters._
 import com.github.pjfanning.pekkohttpspi.PekkoHttpClient
 import org.scalatest.BeforeAndAfterAll
 import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpecLike
 

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/ElasticsearchConnectionSettings.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/ElasticsearchConnectionSettings.scala
@@ -18,8 +18,8 @@ import pekko.http.scaladsl.{ ConnectionContext, HttpsConnectionContext }
 import pekko.http.scaladsl.model.HttpHeader
 import pekko.http.scaladsl.model.HttpHeader.ParsingResult
 import pekko.japi.Util
+import pekko.util.ccompat.JavaConverters._
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import javax.net.ssl.SSLContext
 import scala.compat.java8.OptionConverters
 

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/WriteMessage.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/WriteMessage.scala
@@ -16,8 +16,8 @@ package org.apache.pekko.stream.connectors.elasticsearch
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
+import pekko.util.ccompat.JavaConverters._
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 /**

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -17,9 +17,8 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.ApiMayChange
 import pekko.stream.connectors.elasticsearch.{ scaladsl, _ }
+import pekko.util.ccompat.JavaConverters._
 import com.fasterxml.jackson.databind.ObjectMapper
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Java API to create Elasticsearch flows.

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/javadsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/javadsl/ElasticsearchSource.scala
@@ -20,10 +20,10 @@ import pekko.http.scaladsl.{ Http, HttpExt }
 import pekko.stream.connectors.elasticsearch.{ impl, _ }
 import pekko.stream.javadsl.Source
 import pekko.stream.{ Attributes, Materializer }
+import pekko.util.ccompat.JavaConverters._
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.{ ArrayNode, NumericNode }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 /**

--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/javadsl/LogRotatorSink.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/javadsl/LogRotatorSink.scala
@@ -24,8 +24,8 @@ import pekko.stream.scaladsl
 import pekko.stream.javadsl.Sink
 import pekko.util.ByteString
 import pekko.japi.function
+import pekko.util.ccompat.JavaConverters._
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 
 import scala.compat.java8.FutureConverters._

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -24,13 +24,13 @@ import pekko.stream.scaladsl.{ FileIO, Sink, Source }
 import pekko.testkit.TestKit
 import pekko.util.ByteString
 import pekko.NotUsed
+import pekko.util.ccompat.JavaConverters._
 import docs.javadsl.ArchiveHelper
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.{ ExecutionContext, Future }
 
 class ArchiveSpec

--- a/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
@@ -26,13 +26,13 @@ import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.scaladsl.{ FileIO, Flow, Sink, Source }
 import pekko.testkit.TestKit
 import pekko.util.ByteString
+import pekko.util.ccompat.JavaConverters._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.{ Eventually, IntegrationPatience, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.annotation.nowarn
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/SftpOperations.scala
@@ -18,7 +18,9 @@ import java.io.{ File, IOException, InputStream, OutputStream }
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.charset.StandardCharsets
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import pekko.util.ccompat.JavaConverters._
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.sftp.{ OpenMode, RemoteResourceInfo, SFTPClient }
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
@@ -28,7 +30,6 @@ import net.schmizz.sshj.userauth.password.{ PasswordFinder, PasswordUtils, Resou
 import net.schmizz.sshj.xfer.FilePermission
 import org.apache.commons.net.DefaultSocketFactory
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.util.{ Failure, Try }
 

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/ProtobufConverters.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/ProtobufConverters.scala
@@ -13,12 +13,12 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.bigquery.storage
 
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import pekko.util.ccompat.JavaConverters._
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions
 import com.google.cloud.bigquery.storage.v1.stream.ReadSession
 import scalapb.UnknownFieldSet
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Internal API

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/impl/ArrowSource.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/impl/ArrowSource.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryRecord
 import pekko.stream.scaladsl.Source
+import pekko.util.ccompat.JavaConverters._
 import com.google.cloud.bigquery.storage.v1.arrow.{ ArrowRecordBatch, ArrowSchema }
 import com.google.cloud.bigquery.storage.v1.storage.BigQueryReadClient
 import com.google.cloud.bigquery.storage.v1.stream.ReadSession
@@ -28,7 +29,6 @@ import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 object ArrowSource {
 

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryArrowStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryArrowStorage.scala
@@ -19,10 +19,10 @@ import pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryRecord
 import pekko.stream.javadsl.Source
 import com.google.cloud.bigquery.storage.v1.stream.ReadSession.TableReadOptions
 import pekko.stream.connectors.googlecloud.bigquery.storage.{ scaladsl => scstorage }
+import pekko.util.ccompat.JavaConverters._
 import com.google.cloud.bigquery.storage.v1.arrow.{ ArrowRecordBatch, ArrowSchema }
 
 import java.util.concurrent.CompletionStage
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters.FutureOps
 
 /**

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryAvroStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryAvroStorage.scala
@@ -17,11 +17,11 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.connectors.googlecloud.bigquery.storage.{ scaladsl => scstorage, BigQueryRecord }
 import pekko.stream.javadsl.Source
+import pekko.util.ccompat.JavaConverters._
 import com.google.cloud.bigquery.storage.v1.avro.{ AvroRows, AvroSchema }
 import com.google.cloud.bigquery.storage.v1.stream.ReadSession.TableReadOptions
 
 import java.util.concurrent.CompletionStage
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters.FutureOps
 
 /**

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorage.scala
@@ -20,6 +20,7 @@ import pekko.http.scaladsl.unmarshalling.FromByteStringUnmarshaller
 import pekko.stream.connectors.googlecloud.bigquery.storage.ProtobufConverters._
 import pekko.stream.connectors.googlecloud.bigquery.storage.{ scaladsl => scstorage }
 import pekko.stream.javadsl.Source
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import com.google.cloud.bigquery.storage.v1.DataFormat
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions
@@ -28,7 +29,6 @@ import com.google.cloud.bigquery.storage.v1.stream.ReadSession
 
 import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters.FutureOps
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Google BigQuery Storage Api Akka Stream operator factory.

--- a/google-cloud-bigquery-storage/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/AvroByteStringDecoder.scala
+++ b/google-cloud-bigquery-storage/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/AvroByteStringDecoder.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.http.scaladsl.unmarshalling.FromByteStringUnmarshaller
 import pekko.stream.Materializer
 import pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryRecord
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import org.apache.avro.Schema
 import org.apache.avro.file.SeekableByteArrayInput
@@ -26,7 +27,6 @@ import org.apache.avro.io.DecoderFactory
 import java.util
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ ExecutionContext, Future }
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 class AvroByteStringDecoder(schema: Schema) extends FromByteStringUnmarshaller[java.util.List[BigQueryRecord]] {
 

--- a/google-cloud-bigquery-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/scaladsl/ArrowByteStringDecoder.scala
+++ b/google-cloud-bigquery-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/scaladsl/ArrowByteStringDecoder.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.http.scaladsl.unmarshalling.FromByteStringUnmarshaller
 import pekko.stream.Materializer
 import pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryRecord
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import com.google.cloud.bigquery.storage.v1.arrow.ArrowSchema
 import org.apache.arrow.memory.RootAllocator
@@ -28,7 +29,6 @@ import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ ExecutionContext, Future }
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 class ArrowByteStringDecoder(val schema: ArrowSchema) extends FromByteStringUnmarshaller[List[BigQueryRecord]] {
 

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/javadsl/BigQuery.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/javadsl/BigQuery.scala
@@ -38,13 +38,13 @@ import pekko.stream.javadsl.{ Flow, Sink, Source }
 import pekko.stream.{ scaladsl => ss }
 import pekko.util.ByteString
 import pekko.{ Done, NotUsed }
+import pekko.util.ccompat.JavaConverters._
 
 import java.time.Duration
 import java.util.concurrent.CompletionStage
 import java.{ lang, util }
 
 import scala.annotation.nowarn
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.{ FiniteDuration, MILLISECONDS }

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/DatasetJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/DatasetJsonProtocol.scala
@@ -16,10 +16,10 @@ package org.apache.pekko.stream.connectors.googlecloud.bigquery.model
 import org.apache.pekko
 import pekko.stream.connectors.google.scaladsl.Paginated
 import pekko.stream.connectors.googlecloud.bigquery.scaladsl.spray.BigQueryRestJsonProtocol._
+import pekko.util.ccompat.JavaConverters._
 import spray.json.{ JsonFormat, RootJsonFormat }
 
 import java.util
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/JobJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/JobJsonProtocol.scala
@@ -13,14 +13,15 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.bigquery.model
 
-import org.apache.pekko.stream.connectors.googlecloud.bigquery.scaladsl.spray.BigQueryRestJsonProtocol._
+import org.apache.pekko
+import pekko.stream.connectors.googlecloud.bigquery.scaladsl.spray.BigQueryRestJsonProtocol._
+import pekko.util.ccompat.JavaConverters._
 import com.fasterxml.jackson.annotation.{ JsonCreator, JsonProperty }
 import spray.json.{ JsonFormat, RootJsonFormat }
 
 import java.util
 
 import scala.annotation.nowarn
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/QueryJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/QueryJsonProtocol.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.stream.connectors.google.scaladsl.Paginated
 import pekko.stream.connectors.googlecloud.bigquery.scaladsl.spray.BigQueryRestJsonProtocol._
 import pekko.stream.connectors.googlecloud.bigquery.scaladsl.spray.BigQueryRootJsonReader
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.JavaDurationConverters._
 import com.fasterxml.jackson.annotation.{ JsonCreator, JsonIgnoreProperties, JsonProperty }
 import spray.json.{ RootJsonFormat, RootJsonReader }
@@ -26,7 +27,6 @@ import java.{ lang, util }
 
 import scala.annotation.nowarn
 import scala.annotation.unchecked.uncheckedVariance
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.FiniteDuration

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/TableDataJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/TableDataJsonProtocol.scala
@@ -17,6 +17,7 @@ import org.apache.pekko
 import pekko.stream.connectors.google.scaladsl.Paginated
 import pekko.stream.connectors.googlecloud.bigquery.scaladsl.spray.BigQueryRestJsonProtocol._
 import pekko.stream.connectors.googlecloud.bigquery.scaladsl.spray.{ BigQueryRootJsonReader, BigQueryRootJsonWriter }
+import pekko.util.ccompat.JavaConverters._
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation._
 import spray.json.{ JsonFormat, RootJsonFormat, RootJsonReader, RootJsonWriter }
@@ -25,7 +26,6 @@ import java.{ lang, util }
 
 import scala.annotation.nowarn
 import scala.annotation.unchecked.uncheckedVariance
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/TableJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/TableJsonProtocol.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.stream.connectors.googlecloud.bigquery.model
 import org.apache.pekko
 import pekko.stream.connectors.google.scaladsl.Paginated
 import pekko.stream.connectors.googlecloud.bigquery.scaladsl.spray.BigQueryRestJsonProtocol._
+import pekko.util.ccompat.JavaConverters._
 import com.fasterxml.jackson.annotation.{ JsonCreator, JsonProperty }
 import spray.json.{ JsonFormat, RootJsonFormat }
 
@@ -25,7 +26,6 @@ import scala.annotation.nowarn
 import scala.annotation.varargs
 import scala.collection.immutable.Seq
 import scala.compat.java8.OptionConverters._
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Table resource model

--- a/google-cloud-bigquery/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/A.scala
+++ b/google-cloud-bigquery/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/A.scala
@@ -13,7 +13,9 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.bigquery.e2e
 
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.util.ccompat.JavaConverters._
+import pekko.util.ByteString
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.{ JsonCreator, JsonInclude, JsonProperty, JsonPropertyOrder }
 import com.fasterxml.jackson.databind.JsonNode
@@ -21,7 +23,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 
 import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime }
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 @JsonPropertyOrder(alphabetic = true)
 case class A(integer: Int, long: Long, float: Float, double: Double, string: String, boolean: Boolean, record: B) {

--- a/google-cloud-bigquery/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/EndToEndHelper.scala
+++ b/google-cloud-bigquery/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/EndToEndHelper.scala
@@ -13,8 +13,9 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.bigquery.e2e.javadsl
 
-import org.apache.pekko.stream.connectors.googlecloud.bigquery.e2e.scaladsl
-import org.apache.pekko.util.ccompat.JavaConverters._
+import org.apache.pekko
+import pekko.stream.connectors.googlecloud.bigquery.e2e.scaladsl
+import pekko.util.ccompat.JavaConverters._
 
 abstract class EndToEndHelper extends scaladsl.EndToEndHelper {
 

--- a/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/javadsl/GooglePubSub.scala
@@ -19,11 +19,11 @@ import pekko.stream.connectors.googlecloud.pubsub.scaladsl.{ GooglePubSub => GPu
 import pekko.stream.connectors.googlecloud.pubsub.{ AcknowledgeRequest, PubSubConfig, PublishRequest, ReceivedMessage }
 import pekko.stream.javadsl.{ Flow, FlowWithContext, Sink, Source }
 import pekko.{ Done, NotUsed }
+import pekko.util.ccompat.JavaConverters._
 
 import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Java DSL for Google Pub/Sub

--- a/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/model.scala
+++ b/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/model.scala
@@ -19,10 +19,10 @@ import pekko.actor.ActorSystem
 import pekko.annotation.InternalApi
 import pekko.stream.connectors.google.GoogleSettings
 import pekko.stream.connectors.google.auth.ServiceAccountCredentials
+import pekko.util.ccompat.JavaConverters._
 
 import scala.annotation.nowarn
 import scala.collection.immutable
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * @param projectId (deprecated) the project Id in the google account

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/FailedUpload.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/FailedUpload.scala
@@ -13,8 +13,8 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.storage
 
-import scala.collection.immutable.Seq
 import org.apache.pekko.util.ccompat.JavaConverters._
+import scala.collection.immutable.Seq
 
 final class FailedUpload private (
     val reasons: Seq[Throwable]) extends Exception(reasons.map(_.getMessage).mkString(", ")) {

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/StorageObject.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/StorageObject.scala
@@ -18,8 +18,8 @@ import java.util.Optional
 
 import org.apache.pekko
 import pekko.http.scaladsl.model.ContentType
+import pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Represents an object within Google Cloud Storage.

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/javadsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/javadsl/GCStorage.scala
@@ -24,10 +24,10 @@ import pekko.stream.connectors.googlecloud.storage.impl.GCStorageStream
 import pekko.stream.connectors.googlecloud.storage.{ Bucket, StorageObject }
 import pekko.stream.javadsl.{ RunnableGraph, Sink, Source }
 import pekko.stream.{ Attributes, Materializer }
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import pekko.{ Done, NotUsed }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCSExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCSExtSpec.scala
@@ -16,11 +16,10 @@ package org.apache.pekko.stream.connectors.googlecloud.storage
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
+import pekko.util.ccompat.JavaConverters._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 class GCSExtSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCSExt" should "reuse application config from actor system" in {

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCSSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCSSettingsSpec.scala
@@ -13,12 +13,12 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.storage
 
-import org.apache.pekko.stream.connectors.testkit.scaladsl.LogCapturing
+import org.apache.pekko
+import pekko.stream.connectors.testkit.scaladsl.LogCapturing
+import pekko.util.ccompat.JavaConverters._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 class GCSSettingsSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCSSettings" should "create settings from application config" in {

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageExtSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageExtSpec.scala
@@ -16,12 +16,12 @@ package org.apache.pekko.stream.connectors.googlecloud.storage
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
+import pekko.util.ccompat.JavaConverters._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.annotation.nowarn
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 class GCStorageExtSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCStorageExt" should "reuse application config from actor system" in {

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageSettingsSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageSettingsSpec.scala
@@ -13,13 +13,14 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.storage
 
-import org.apache.pekko.stream.connectors.testkit.scaladsl.LogCapturing
+import org.apache.pekko
+import pekko.stream.connectors.testkit.scaladsl.LogCapturing
+import pekko.util.ccompat.JavaConverters._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.annotation.nowarn
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 class GCStorageSettingsSpec extends AnyFlatSpec with Matchers with LogCapturing {
   "GCStorageSettings" should "create settings from application config" in {

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/ServiceAccountCredentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/ServiceAccountCredentials.scala
@@ -18,12 +18,12 @@ import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.InternalApi
 import pekko.stream.Materializer
 import pekko.stream.connectors.google.RequestSettings
+import pekko.util.ccompat.JavaConverters._
 import com.typesafe.config.Config
 import spray.json.DefaultJsonProtocol._
 import spray.json.{ JsonParser, RootJsonFormat }
 
 import java.time.Clock
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 import scala.io.Source
 

--- a/hdfs/src/test/scala/org/apache/pekko/stream/connectors/hdfs/util/TestUtils.scala
+++ b/hdfs/src/test/scala/org/apache/pekko/stream/connectors/hdfs/util/TestUtils.scala
@@ -187,7 +187,7 @@ object JavaTestUtils extends TestUtils {
 
   import org.junit.Assert._
 
-  import org.apache.pekko.util.ccompat.JavaConverters._
+  import pekko.util.ccompat.JavaConverters._
 
   val books: util.List[ByteString] = ScalaTestUtils.books.asJava
 

--- a/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/AlpakkaResultMapperHelper.scala
+++ b/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/AlpakkaResultMapperHelper.scala
@@ -22,11 +22,11 @@ import org.influxdb.annotation.{ Column, Measurement }
 import org.influxdb.dto.QueryResult
 
 import java.util.concurrent.TimeUnit
-import org.apache.pekko.annotation.InternalApi
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import pekko.util.ccompat.JavaConverters._
 import org.influxdb.InfluxDBMapperException
 import org.influxdb.dto.Point
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Internal API.

--- a/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/InfluxDbSourceStage.scala
+++ b/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/InfluxDbSourceStage.scala
@@ -18,10 +18,9 @@ import pekko.annotation.InternalApi
 import pekko.stream.connectors.influxdb.InfluxDbReadSettings
 import pekko.stream.{ ActorAttributes, Attributes, Outlet, SourceShape }
 import pekko.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
+import pekko.util.ccompat.JavaConverters._
 import org.influxdb.{ InfluxDB, InfluxDBException }
 import org.influxdb.dto.{ Query, QueryResult }
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * INTERNAL API

--- a/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/javadsl/InfluxDbFlow.scala
+++ b/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/javadsl/InfluxDbFlow.scala
@@ -20,9 +20,8 @@ import pekko.stream.connectors.influxdb.{ InfluxDbWriteMessage, InfluxDbWriteRes
 import org.influxdb.InfluxDB
 import pekko.stream.javadsl.Flow
 import pekko.stream.connectors.influxdb.scaladsl
+import pekko.util.ccompat.JavaConverters._
 import org.influxdb.dto.Point
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * API may change.

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
@@ -25,9 +25,9 @@ import pekko.stream.connectors.influxdb.{ InfluxDbReadSettings, InfluxDbWriteMes
 import pekko.stream.connectors.influxdb.scaladsl.{ InfluxDbSink, InfluxDbSource }
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.testkit.TestKit
+import pekko.util.ccompat.JavaConverters._
 import pekko.stream.scaladsl.Sink
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import docs.javadsl.TestUtils._
 import docs.javadsl.TestConstants.{ INFLUXDB_URL, PASSWORD, USERNAME }
 import org.scalatest.matchers.must.Matchers

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/JmsMessages.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/JmsMessages.scala
@@ -18,8 +18,8 @@ import javax.jms
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.connectors.jms.impl.JmsMessageReader._
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 /**

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsMessageReader.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsMessageReader.scala
@@ -18,9 +18,9 @@ import javax.jms
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream.connectors.jms._
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import scala.annotation.tailrec
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 @InternalApi
 private[jms] object JmsMessageReader {

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/javadsl/JmsConsumer.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/javadsl/JmsConsumer.scala
@@ -16,10 +16,9 @@ package org.apache.pekko.stream.connectors.jms.javadsl
 import javax.jms.Message
 import org.apache.pekko
 import pekko.NotUsed
+import pekko.util.ccompat.JavaConverters._
 import pekko.stream.connectors.jms._
 import pekko.stream.javadsl.Source
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Factory methods to create JMS consumers.

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/javadsl/JmsProducer.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/javadsl/JmsProducer.scala
@@ -19,10 +19,10 @@ import org.apache.pekko
 import pekko.stream.connectors.jms.{ scaladsl, JmsEnvelope, JmsMessage, JmsProducerSettings }
 import pekko.stream.javadsl.Source
 import pekko.stream.scaladsl.{ Flow, Keep }
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import pekko.{ Done, NotUsed }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters
 
 /**

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/scaladsl/JmsConsumer.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/scaladsl/JmsConsumer.scala
@@ -18,9 +18,8 @@ import pekko.NotUsed
 import pekko.stream.connectors.jms._
 import pekko.stream.connectors.jms.impl._
 import pekko.stream.scaladsl.Source
+import pekko.util.ccompat.JavaConverters._
 import javax.jms
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Factory methods to create JMS consumers.

--- a/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
@@ -23,6 +23,7 @@ import pekko.stream._
 import pekko.stream.connectors.jms._
 import pekko.stream.connectors.jms.scaladsl._
 import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import pekko.util.ccompat.JavaConverters._
 import pekko.{ Done, NotUsed }
 import javax.jms._
 
@@ -34,7 +35,6 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 
 import scala.annotation.tailrec
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.collection.mutable
 import scala.concurrent.Future

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSourceStage.scala
@@ -21,11 +21,11 @@ import pekko.stream.connectors.kinesis.{ KinesisErrors => Errors, ShardSettings 
 import pekko.stream.stage.GraphStageLogic.StageActor
 import pekko.stream.stage._
 import pekko.stream.{ Attributes, Outlet, SourceShape }
+import pekko.util.ccompat.JavaConverters._
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.services.kinesis.model._
 
 import scala.collection.mutable
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.util.{ Failure, Success, Try }
 
 import scala.compat.java8.FutureConverters._

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/ShardProcessor.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/ShardProcessor.scala
@@ -19,12 +19,11 @@ import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream.connectors.kinesis.CommittableRecord
 import pekko.stream.connectors.kinesis.CommittableRecord.{ BatchData, ShardProcessorData }
+import pekko.util.ccompat.JavaConverters._
 import software.amazon.kinesis.lifecycle.ShutdownReason
 import software.amazon.kinesis.lifecycle.events._
 import software.amazon.kinesis.processor.{ RecordProcessorCheckpointer, ShardRecordProcessor }
 import software.amazon.kinesis.retrieval.KinesisClientRecord
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 @InternalApi
 private[kinesis] class ShardProcessor(

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/javadsl/KinesisSource.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/javadsl/KinesisSource.scala
@@ -17,10 +17,9 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.connectors.kinesis.{ scaladsl, ShardSettings }
 import pekko.stream.javadsl.Source
+import pekko.util.ccompat.JavaConverters._
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.services.kinesis.model.Record
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 object KinesisSource {
 

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/scaladsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/scaladsl/KinesisFlow.scala
@@ -22,6 +22,7 @@ import pekko.stream.ThrottleMode
 import pekko.stream.connectors.kinesis.KinesisFlowSettings
 import pekko.stream.connectors.kinesis.KinesisErrors.FailurePublishingRecords
 import pekko.stream.scaladsl.{ Flow, FlowWithContext }
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
@@ -32,7 +33,6 @@ import software.amazon.awssdk.services.kinesis.model.{
   PutRecordsResultEntry
 }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Queue
 import scala.concurrent.duration._
 import scala.compat.java8.FutureConverters._

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesisfirehose/scaladsl/KinesisFirehoseFlow.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesisfirehose/scaladsl/KinesisFirehoseFlow.scala
@@ -20,10 +20,10 @@ import pekko.stream.ThrottleMode
 import pekko.stream.connectors.kinesisfirehose.KinesisFirehoseFlowSettings
 import pekko.stream.connectors.kinesisfirehose.KinesisFirehoseErrors.FailurePublishingRecords
 import pekko.stream.scaladsl.Flow
+import pekko.util.ccompat.JavaConverters._
 import software.amazon.awssdk.services.firehose.FirehoseAsyncClient
 import software.amazon.awssdk.services.firehose.model.{ PutRecordBatchRequest, PutRecordBatchResponseEntry, Record }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Queue
 import scala.concurrent.duration._
 

--- a/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisFlowSpec.scala
@@ -22,6 +22,7 @@ import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.scaladsl.Keep
 import pekko.stream.testkit.scaladsl.{ TestSink, TestSource }
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -31,8 +32,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kinesis.model._
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with LogCapturing {
 

--- a/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisSchedulerSourceSpec.scala
+++ b/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisSchedulerSourceSpec.scala
@@ -28,6 +28,7 @@ import pekko.stream.connectors.testkit.scaladsl.Repeated
 import pekko.stream.scaladsl.Keep
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import pekko.stream.testkit.scaladsl.{ TestSink, TestSource }
+import pekko.util.ccompat.JavaConverters._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -47,7 +48,6 @@ import software.amazon.kinesis.processor.{
 import software.amazon.kinesis.retrieval.KinesisClientRecord
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random

--- a/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesisfirehose/KinesisFirehoseFlowSpec.scala
+++ b/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesisfirehose/KinesisFirehoseFlowSpec.scala
@@ -22,6 +22,7 @@ import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.scaladsl.Keep
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import pekko.stream.testkit.scaladsl.{ TestSink, TestSource }
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -31,8 +32,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.firehose.model._
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 class KinesisFirehoseFlowSpec extends AnyWordSpec with Matchers with KinesisFirehoseMock with LogCapturing {
 

--- a/kudu/src/main/scala/org/apache/pekko/stream/connectors/kudu/impl/KuduFlowStage.scala
+++ b/kudu/src/main/scala/org/apache/pekko/stream/connectors/kudu/impl/KuduFlowStage.scala
@@ -18,11 +18,11 @@ import pekko.annotation.InternalApi
 import pekko.stream._
 import pekko.stream.connectors.kudu.KuduTableSettings
 import pekko.stream.stage._
+import pekko.util.ccompat.JavaConverters._
 import org.apache.kudu.Schema
 import org.apache.kudu.Type._
 import org.apache.kudu.client.{ KuduClient, KuduTable, PartialRow }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.util.control.NonFatal
 
 /**

--- a/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
+++ b/kudu/src/test/scala/docs/scaladsl/KuduTableSpec.scala
@@ -21,12 +21,12 @@ import pekko.stream.connectors.kudu.scaladsl.KuduTable
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.scaladsl.{ Flow, Sink, Source }
 import pekko.testkit.TestKit
+import pekko.util.ccompat.JavaConverters._
 import org.apache.kudu.client.{ CreateTableOptions, KuduClient, PartialRow }
 import org.apache.kudu.{ ColumnSchema, Schema, Type }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers

--- a/mongodb/src/main/scala/org/apache/pekko/stream/connectors/mongodb/javadsl/MongoFlow.scala
+++ b/mongodb/src/main/scala/org/apache/pekko/stream/connectors/mongodb/javadsl/MongoFlow.scala
@@ -24,12 +24,11 @@ import pekko.stream.connectors.mongodb.scaladsl.MongoFlow.{
   DefaultUpdateOptions
 }
 import pekko.stream.javadsl.Flow
+import pekko.util.ccompat.JavaConverters._
 import com.mongodb.client.model.{ DeleteOptions, InsertManyOptions, InsertOneOptions, ReplaceOptions, UpdateOptions }
 import com.mongodb.client.result.{ DeleteResult, UpdateResult }
 import com.mongodb.reactivestreams.client.MongoCollection
 import org.bson.conversions.Bson
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 object MongoFlow {
 

--- a/mongodb/src/main/scala/org/apache/pekko/stream/connectors/mongodb/scaladsl/MongoFlow.scala
+++ b/mongodb/src/main/scala/org/apache/pekko/stream/connectors/mongodb/scaladsl/MongoFlow.scala
@@ -18,12 +18,11 @@ import pekko.stream.scaladsl.{ Flow, Source }
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 import pekko.stream.connectors.mongodb.{ DocumentReplace, DocumentUpdate }
+import pekko.util.ccompat.JavaConverters._
 import com.mongodb.client.model.{ DeleteOptions, InsertManyOptions, InsertOneOptions, ReplaceOptions, UpdateOptions }
 import com.mongodb.client.result.{ DeleteResult, UpdateResult }
 import com.mongodb.reactivestreams.client.MongoCollection
 import org.bson.conversions.Bson
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 object MongoFlow {
 

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
@@ -20,6 +20,7 @@ import pekko.stream.connectors.mongodb.scaladsl.MongoSink
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import pekko.util.ccompat.JavaConverters._
 import com.mongodb.client.model.{ Filters, InsertManyOptions, Updates }
 import com.mongodb.reactivestreams.client.{ MongoClients, MongoCollection }
 import org.bson.Document
@@ -29,7 +30,6 @@ import org.mongodb.scala.bson.codecs.Macros._
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
@@ -20,12 +20,12 @@ import pekko.stream.connectors.mongodb.scaladsl.MongoSource
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import pekko.util.ccompat.JavaConverters._
 import com.mongodb.reactivestreams.client.MongoClients
 import org.bson.Document
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.concurrent.duration._

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/model.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/model.scala
@@ -23,11 +23,11 @@ import pekko.Done
 import pekko.annotation.InternalApi
 import pekko.japi.{ Pair => AkkaPair }
 import pekko.stream.connectors.mqtt.streaming.Connect.ProtocolLevel
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.{ ByteIterator, ByteString, ByteStringBuilder }
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.{ ExecutionContext, Promise }
 

--- a/mqtt/src/main/scala/org/apache/pekko/stream/connectors/mqtt/settings.scala
+++ b/mqtt/src/main/scala/org/apache/pekko/stream/connectors/mqtt/settings.scala
@@ -14,10 +14,10 @@
 package org.apache.pekko.stream.connectors.mqtt
 
 import org.apache.pekko
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.JavaDurationConverters._
 import org.eclipse.paho.client.mqttv3.{ MqttClientPersistence, MqttConnectOptions }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.collection.immutable.Map
 import scala.concurrent.duration.{ FiniteDuration, _ }

--- a/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/impl/OrientDbSourceStage.scala
+++ b/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/impl/OrientDbSourceStage.scala
@@ -20,11 +20,10 @@ import pekko.annotation.InternalApi
 import pekko.stream.connectors.orientdb.{ OrientDbReadResult, OrientDbSourceSettings }
 import pekko.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
 import pekko.stream.{ ActorAttributes, Attributes, Outlet, SourceShape }
+import pekko.util.ccompat.JavaConverters._
 import com.orientechnologies.orient.`object`.db.OObjectDatabaseTx
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * INTERNAL API

--- a/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/javadsl/OrientDbFlow.scala
+++ b/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/javadsl/OrientDbFlow.scala
@@ -17,9 +17,8 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.connectors.orientdb._
 import pekko.stream.javadsl.Flow
+import pekko.util.ccompat.JavaConverters._
 import com.orientechnologies.orient.core.record.impl.ODocument
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Java API.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val Scala212 = "2.12.17"
   val ScalaVersions = Seq(Scala213, Scala212)
 
-  val PekkoVersion = "0.0.0+26610-defddc6a-SNAPSHOT"
+  val PekkoVersion = "0.0.0+26621-44d03df6-SNAPSHOT"
   val AkkaBinaryVersion = "2.6"
 
   val InfluxDBJavaVersion = "2.15"

--- a/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/model.scala
+++ b/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/model.scala
@@ -17,10 +17,10 @@ import java.util.{ Optional, OptionalInt }
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 
 import scala.collection.immutable
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.util.{ Success, Try }
 

--- a/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/testkit/MessageFactory.scala
+++ b/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/testkit/MessageFactory.scala
@@ -16,10 +16,10 @@ package org.apache.pekko.stream.connectors.reference.testkit
 import org.apache.pekko
 import pekko.annotation.ApiMayChange
 import pekko.stream.connectors.reference.{ ReferenceReadResult, ReferenceWriteMessage, ReferenceWriteResult }
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 
 import scala.collection.immutable
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.util.{ Failure, Success, Try }
 
 @ApiMayChange

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/S3Headers.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/S3Headers.scala
@@ -21,9 +21,9 @@ import pekko.http.scaladsl.model.HttpHeader
 import pekko.http.scaladsl.model.headers.RawHeader
 import pekko.stream.connectors.s3.headers.{ CannedAcl, ServerSideEncryption, StorageClass }
 import pekko.stream.connectors.s3.impl.S3Request
+import pekko.util.ccompat.JavaConverters._
 
 import scala.collection.immutable.Seq
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 final class MetaHeaders private (val metaHeaders: Map[String, String]) {
 

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
@@ -29,9 +29,9 @@ import pekko.stream.connectors.s3.headers.{ CannedAcl, ServerSideEncryption }
 import pekko.stream.connectors.s3._
 import pekko.stream.connectors.s3.impl._
 import pekko.stream.javadsl.{ RunnableGraph, Sink, Source }
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
 

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/model.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/model.scala
@@ -19,11 +19,11 @@ import org.apache.pekko
 import pekko.http.scaladsl.model.{ DateTime, HttpHeader, IllegalUriException, Uri }
 import pekko.http.scaladsl.model.headers._
 import pekko.stream.connectors.s3.AccessStyle.PathAccessStyle
+import pekko.util.ccompat.JavaConverters._
 
 import scala.annotation.nowarn
 import scala.collection.immutable.Seq
 import scala.collection.immutable
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 final class MultipartUpload private (val bucket: String, val key: String, val uploadId: String) {

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3ExtSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3ExtSpec.scala
@@ -17,11 +17,10 @@ import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.stream.connectors.s3.AccessStyle.PathAccessStyle
 import pekko.stream.connectors.s3.S3Ext
+import pekko.util.ccompat.JavaConverters._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 class S3ExtSpec extends AnyFlatSpecLike with Matchers {
   it should "reuse application config from actor system" in {

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
@@ -24,6 +24,7 @@ import pekko.stream.connectors.s3._
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.scaladsl.{ Keep, Sink, Source }
 import pekko.testkit.{ TestKit, TestKitBase }
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import pekko.{ Done, NotUsed }
 import org.scalatest.Inspectors.forEvery
@@ -40,7 +41,6 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 trait S3IntegrationSpec
     extends AnyFlatSpecLike

--- a/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/SolrMessages.scala
+++ b/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/SolrMessages.scala
@@ -16,8 +16,7 @@ package org.apache.pekko.stream.connectors.solr
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
-
-import org.apache.pekko.util.ccompat.JavaConverters._
+import pekko.util.ccompat.JavaConverters._
 
 object WriteMessage {
   def createUpsertMessage[T](source: T): WriteMessage[T, NotUsed] =

--- a/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/impl/SolrFlowStage.scala
+++ b/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/impl/SolrFlowStage.scala
@@ -19,6 +19,7 @@ import pekko.stream.ActorAttributes.SupervisionStrategy
 import pekko.stream._
 import pekko.stream.connectors.solr._
 import pekko.stream.stage._
+import pekko.util.ccompat.JavaConverters._
 import org.apache.solr.client.solrj.SolrClient
 import org.apache.solr.client.solrj.impl.CloudSolrClient
 import org.apache.solr.client.solrj.request.UpdateRequest
@@ -29,7 +30,6 @@ import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 import scala.collection.immutable
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Internal API

--- a/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/javadsl/SolrFlow.scala
+++ b/solr/src/main/scala/org/apache/pekko/stream/connectors/solr/javadsl/SolrFlow.scala
@@ -20,10 +20,10 @@ import pekko.NotUsed
 import pekko.stream.connectors.solr.{ scaladsl, SolrUpdateSettings, WriteMessage, WriteResult }
 import pekko.stream.javadsl
 import pekko.stream.scaladsl.Flow
+import pekko.util.ccompat.JavaConverters._
 import org.apache.solr.client.solrj.SolrClient
 import org.apache.solr.common.SolrInputDocument
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 
 /**

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/SqsSourceSettings.scala
@@ -16,9 +16,9 @@ package org.apache.pekko.stream.connectors.sqs
 import java.time.temporal.ChronoUnit
 
 import software.amazon.awssdk.services.sqs.model
+import org.apache.pekko.util.ccompat.JavaConverters._
 
 import scala.collection.immutable
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 
 final class SqsSourceSettings private (

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/javadsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/javadsl/SqsPublishFlow.scala
@@ -25,10 +25,9 @@ import pekko.stream.connectors.sqs.{
 }
 import pekko.stream.javadsl.Flow
 import pekko.stream.scaladsl.{ Flow => SFlow }
+import pekko.util.ccompat.JavaConverters._
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 /**
  * Java API to create SQS flows.

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/javadsl/SqsPublishSink.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/javadsl/SqsPublishSink.scala
@@ -20,10 +20,10 @@ import pekko.Done
 import pekko.stream.connectors.sqs._
 import pekko.stream.javadsl.Sink
 import pekko.stream.scaladsl.{ Flow, Keep }
+import pekko.util.ccompat.JavaConverters._
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters.FutureOps
 
 /**

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsAckFlow.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsAckFlow.scala
@@ -25,10 +25,10 @@ import pekko.stream.connectors.sqs.SqsAckResult._
 import pekko.stream.connectors.sqs.SqsAckResultEntry._
 import pekko.stream.connectors.sqs._
 import pekko.stream.scaladsl.{ Flow, GraphDSL, Merge, Partition }
+import pekko.util.ccompat.JavaConverters._
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsPublishFlow.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsPublishFlow.scala
@@ -21,10 +21,10 @@ import pekko.annotation.ApiMayChange
 import pekko.dispatch.ExecutionContexts.parasitic
 import pekko.stream.connectors.sqs._
 import pekko.stream.scaladsl.{ Flow, Source }
+import pekko.util.ccompat.JavaConverters._
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters._
 
 /**

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsSource.scala
@@ -19,10 +19,10 @@ import pekko.stream._
 import pekko.stream.connectors.sqs.SqsSourceSettings
 import pekko.stream.connectors.sqs.impl.BalancingMapAsync
 import pekko.stream.scaladsl.{ Flow, Source }
+import pekko.util.ccompat.JavaConverters._
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.compat.java8.FutureConverters._
 
 /**

--- a/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsAckSpec.scala
@@ -24,6 +24,7 @@ import pekko.stream.connectors.sqs.SqsAckResult._
 import pekko.stream.connectors.sqs.SqsAckResultEntry._
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.util.ccompat.JavaConverters._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{ spy, times, verify, when }
 import org.scalatest.flatspec.AnyFlatSpec
@@ -32,7 +33,6 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model._
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 
 class SqsAckSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {

--- a/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsPublishSpec.scala
@@ -21,12 +21,12 @@ import pekko.stream.connectors.sqs._
 import pekko.stream.connectors.sqs.scaladsl._
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.util.ccompat.JavaConverters._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.{ Message, ReceiveMessageRequest, SendMessageRequest }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 
 class SqsPublishSpec extends AnyFlatSpec with Matchers with DefaultTestContext with LogCapturing {

--- a/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
+++ b/sqs/src/test/scala/docs/scaladsl/SqsSourceSpec.scala
@@ -23,6 +23,7 @@ import pekko.stream.connectors.sqs._
 import pekko.stream.connectors.sqs.scaladsl.{ DefaultTestContext, SqsSource }
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.scaladsl.{ Keep, Sink }
+import pekko.util.ccompat.JavaConverters._
 import com.github.pjfanning.pekkohttpspi.PekkoHttpClient
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -39,7 +40,6 @@ import software.amazon.awssdk.services.sqs.model.{
   SendMessageRequest
 }
 
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/sqs/src/test/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/DefaultTestContext.scala
+++ b/sqs/src/test/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/DefaultTestContext.scala
@@ -20,6 +20,7 @@ import org.apache.pekko
 import pekko.actor.{ ActorSystem, Terminated }
 import pekko.http.scaladsl.Http
 import pekko.stream.connectors.sqs.SqsSourceSettings
+import pekko.util.ccompat.JavaConverters._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{ BeforeAndAfterAll, Suite, Tag }
@@ -32,7 +33,6 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
 //#init-client
-import org.apache.pekko.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.Random
 

--- a/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/CapturingAppender.scala
+++ b/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/CapturingAppender.scala
@@ -99,7 +99,7 @@ import org.slf4j.LoggerFactory
    * Also clears the buffer..
    */
   def flush(sourceActorSystem: Option[String]): Unit = synchronized {
-    import org.apache.pekko.util.ccompat.JavaConverters._
+    import pekko.util.ccompat.JavaConverters._
     val logbackLogger = getLogbackLogger(classOf[CapturingAppender].getName + "Delegate")
     val appenders = logbackLogger.iteratorForAppenders().asScala.filterNot(_ == this).toList
     for (event <- buffer; appender <- appenders) {

--- a/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
+++ b/text/src/test/scala/docs/scaladsl/CharsetCodingFlowsDoc.scala
@@ -51,9 +51,9 @@ class CharsetCodingFlowsDoc
       import org.apache.pekko
       import pekko.stream.connectors.text.scaladsl.TextFlow
       import pekko.stream.scaladsl.FileIO
+      import pekko.util.ccompat.JavaConverters._
 
       // #encoding
-      import org.apache.pekko.util.ccompat.JavaConverters._
       val targetFile = Paths.get("target/outdata.txt")
       val strings = System.getProperties.asScala.map(p => p._1 + " -> " + p._2).toList
       // #encoding

--- a/text/src/test/scala/org/apache/pekko/stream/connectors/text/scaladsl/CharsetCodingFlowsSpec.scala
+++ b/text/src/test/scala/org/apache/pekko/stream/connectors/text/scaladsl/CharsetCodingFlowsSpec.scala
@@ -73,9 +73,9 @@ class CharsetCodingFlowsSpec
       import java.nio.charset.StandardCharsets
 
       import pekko.stream.scaladsl.FileIO
+      import pekko.util.ccompat.JavaConverters._
 
       // #encoding
-      import org.apache.pekko.util.ccompat.JavaConverters._
       val targetFile = Paths.get("target/outdata.txt")
       val strings = System.getProperties.asScala.map(p => p._1 + " -> " + p._2).toList
       val stringSource: Source[String, _] = Source(strings)

--- a/xml/src/main/scala/org/apache/pekko/stream/connectors/xml/javadsl/XmlParsing.scala
+++ b/xml/src/main/scala/org/apache/pekko/stream/connectors/xml/javadsl/XmlParsing.scala
@@ -17,13 +17,12 @@ import org.apache.pekko
 import pekko.NotUsed
 import pekko.stream.connectors.xml
 import pekko.stream.connectors.xml.ParseEvent
+import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 import com.fasterxml.aalto.AsyncXMLInputFactory
 import org.w3c.dom.Element
 
 import java.util.function.Consumer
-
-import org.apache.pekko.util.ccompat.JavaConverters._
 
 object XmlParsing {
 

--- a/xml/src/main/scala/org/apache/pekko/stream/connectors/xml/model.scala
+++ b/xml/src/main/scala/org/apache/pekko/stream/connectors/xml/model.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.stream.connectors.xml
 import java.util.Optional
 
 import org.apache.pekko.util.ccompat.JavaConverters._
+
 import scala.compat.java8.OptionConverters._
 
 /**


### PR DESCRIPTION
Updates pekko core snapshot version which includes the latest collection compat (to avoid any potential dependency resolution issues). Also cleans up the imports which was changed in https://github.com/apache/incubator-pekko-connectors/pull/68