### PR TITLE
Finish Scala 2.12 support

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -42,7 +42,7 @@ jobs:
 
       # temporarily remove mima checks
       - name: "Code style, compile tests, MiMa. Run locally with: sbt +~2.13 \"headerCheckAll; verifyCodeFmt; Test/compile; mimaReportBinaryIssues\""
-        run: sbt +~2.13 "headerCheckAll; verifyCodeFmt; Test/compile"
+        run: sbt "headerCheckAll; verifyCodeFmt; +Test/compile"
 
   documentation:
     name: ScalaDoc, Documentation with Paradox

--- a/build.sbt
+++ b/build.sbt
@@ -153,8 +153,15 @@ lazy val geode =
     "geode",
     Dependencies.Geode,
     Test / fork := true,
-    // https://github.com/scala/bug/issues/12072
-    Test / scalacOptions += "-Xlint:-byname-implicit")
+    Test / scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n == 13 =>
+          // https://github.com/scala/bug/issues/12072
+          List("-Xlint:-byname-implicit")
+        case Some((2, n)) if n == 12 =>
+          List.empty
+      }
+    })
 
 lazy val googleCommon = pekkoConnectorProject(
   "google-common",

--- a/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
+++ b/csv/src/test/scala/docs/scaladsl/CsvParsingSpec.scala
@@ -21,6 +21,7 @@ import pekko.stream.connectors.csv.scaladsl.{ CsvParsing, CsvToMap }
 import pekko.stream.scaladsl.{ FileIO, Flow, Keep, Sink, Source }
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import pekko.stream.testkit.scaladsl.{ TestSink, TestSource }
+import pekko.util.ccompat._
 import pekko.util.ByteString
 
 import scala.collection.immutable.Seq

--- a/file/src/test/scala/docs/scaladsl/ExecutableUtils.scala
+++ b/file/src/test/scala/docs/scaladsl/ExecutableUtils.scala
@@ -18,6 +18,7 @@ import java.nio.file.{ Files, Path, Paths }
 
 import org.apache.pekko.util.ByteString
 
+import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.sys.process.{ BasicIO, Process }
 
@@ -57,9 +58,10 @@ object ExecutableUtils {
     finally stream.close()
   }
 
+  @nowarn("msg=deprecated")
   private def readStream(stream: InputStream): ByteString = {
     val reader = new BufferedInputStream(stream)
-    try ByteString(LazyList.continually(reader.read).takeWhile(_ != -1).map(_.toByte).toArray)
+    try ByteString(Stream.continually(reader.read).takeWhile(_ != -1).map(_.toByte).toArray)
     finally reader.close()
   }
 

--- a/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala
+++ b/google-common/src/test/scala/docs/scaladsl/GoogleCommonDoc.scala
@@ -21,8 +21,7 @@ import pekko.stream.scaladsl.Source
 
 import scala.annotation.nowarn
 
-@nowarn("msg=never used")
-@nowarn("msg=dead code")
+@nowarn("msg=never used|dead code")
 class GoogleCommonDoc {
 
   implicit val system: ActorSystem = ???

--- a/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisFlowSpec.scala
@@ -33,6 +33,8 @@ import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kinesis.model._
 
+import scala.annotation.nowarn
+
 class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with LogCapturing {
 
   "KinesisFlow" must {
@@ -101,9 +103,10 @@ class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with Lo
         .run()
   }
 
+  @nowarn("msg=deprecated")
   trait KinesisFlowWithContextProbe { self: Settings =>
     val streamName = "stream-name"
-    val recordStream = LazyList
+    val recordStream = Stream
       .from(1)
       .map(i =>
         (PutRecordsRequestEntry
@@ -112,7 +115,7 @@ class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with Lo
             .data(SdkBytes.fromByteBuffer(ByteString(i).asByteBuffer))
             .build(),
           i))
-    val resultStream = LazyList
+    val resultStream = Stream
       .from(1)
       .map(i => (PutRecordsResultEntry.builder().build(), i))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -121,7 +121,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-slf4j" % PekkoVersion,
       "org.apache.pekko" %% "pekko-stream-testkit" % PekkoVersion % Test,
-      "org.apache.pekko" %% "pekko-connectors-kafka" % "0.0.0+1708-6e5cb74d-SNAPSHOT" % Test,
+      "org.apache.pekko" %% "pekko-connectors-kafka" % "0.0.0+1715-d36a8e1a-SNAPSHOT" % Test,
       "junit" % "junit" % "4.13.2" % Test, // Eclipse Public License 1.0
       "org.scalatest" %% "scalatest" % "3.2.11" % Test // ApacheV2
     ))

--- a/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/model.scala
+++ b/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/model.scala
@@ -17,6 +17,7 @@ import java.util.{ Optional, OptionalInt }
 
 import org.apache.pekko
 import pekko.annotation.InternalApi
+import pekko.util.ccompat._
 import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 

--- a/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/testkit/MessageFactory.scala
+++ b/reference/src/main/scala/org/apache/pekko/stream/connectors/reference/testkit/MessageFactory.scala
@@ -16,6 +16,7 @@ package org.apache.pekko.stream.connectors.reference.testkit
 import org.apache.pekko
 import pekko.annotation.ApiMayChange
 import pekko.stream.connectors.reference.{ ReferenceReadResult, ReferenceWriteMessage, ReferenceWriteResult }
+import pekko.util.ccompat._
 import pekko.util.ccompat.JavaConverters._
 import pekko.util.ByteString
 


### PR DESCRIPTION
Resolves: https://github.com/apache/incubator-pekko-connectors/issues/71

Finishes the Scala 2.12 support. Some more test classes needed to be changed in order to compile, pekko-connectors-kafka version was necessary to bump because a snapshot was just released last night that had 2.12 build plus some other tweaks (see inline comments)