### PR TITLE
Update pekko and remove ByteString Scala 2.12 workaround

### DIFF
--- a/file/src/test/scala/docs/scaladsl/ExecutableUtils.scala
+++ b/file/src/test/scala/docs/scaladsl/ExecutableUtils.scala
@@ -59,7 +59,7 @@ object ExecutableUtils {
 
   private def readStream(stream: InputStream): ByteString = {
     val reader = new BufferedInputStream(stream)
-    try ByteString(Iterator.continually(reader.read).takeWhile(_ != -1).map(_.toByte).toArray)
+    try ByteString(Iterator.continually(reader.read).takeWhile(_ != -1).map(_.toByte))
     finally reader.close()
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val Scala212 = "2.12.17"
   val ScalaVersions = Seq(Scala213, Scala212)
 
-  val PekkoVersion = "0.0.0+26621-44d03df6-SNAPSHOT"
+  val PekkoVersion = "0.0.0+26623-85c2a469-SNAPSHOT"
   val AkkaBinaryVersion = "2.6"
 
   val InfluxDBJavaVersion = "2.15"


### PR DESCRIPTION
Updates Pekko to latest version which brings in the fix for `ByteString`, allowing us to remove the `.toArray` workaround that was introduced in https://github.com/apache/incubator-pekko-connectors/pull/74