### PR TITLE
Update Minio version to improve flakiness

### DIFF
--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/MinioContainer.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/MinioContainer.scala
@@ -20,7 +20,7 @@ import java.time.Duration
 
 class MinioContainer(accessKey: String, secretKey: String, domain: String)
     extends GenericContainer(
-      "minio/minio:RELEASE.2020-03-09T18-26-53Z",
+      "minio/minio:RELEASE.2023-04-13T03-08-07Z",
       exposedPorts = List(9000),
       waitStrategy = Some(Wait.forHttp("/minio/health/ready").forPort(9000).withStartupTimeout(Duration.ofSeconds(10))),
       command = List("server", "/data"),


### PR DESCRIPTION
The latest version of Minio seems to have fixed a flaky bug where the container wasn't started even though it reported itself as ready