### PR TITLE
Only pass SSE headers for multipart upload requests

### DIFF
--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala
@@ -1014,7 +1014,7 @@ import scala.util.{ Failure, Success, Try }
     import mat.executionContext
     implicit val conf: S3Settings = resolveSettings(attr, mat.system)
 
-    val headers = s3Headers.headersFor(UploadPart)
+    val headers = s3Headers.serverSideEncryption.map(_.headersFor(UploadPart)).getOrElse(Nil)
 
     Source
       .future(
@@ -1098,7 +1098,7 @@ import scala.util.{ Failure, Success, Try }
 
     val chunkBufferSize = chunkSize * 2
 
-    val headers = s3Headers.headersFor(UploadPart)
+    val headers = s3Headers.serverSideEncryption.map(_.headersFor(UploadPart)).getOrElse(Nil)
 
     Flow
       .fromMaterializer { (mat, attr) =>
@@ -1189,7 +1189,7 @@ import scala.util.{ Failure, Success, Try }
 
     val chunkBufferSize = chunkSize * 2
 
-    val headers = s3Headers.headersFor(UploadPart)
+    val headers = s3Headers.serverSideEncryption.map(_.headersFor(UploadPart)).getOrElse(Nil)
 
     Flow
       .fromMaterializer { (mat, attr) =>

--- a/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala
+++ b/s3/src/test/scala/docs/scaladsl/S3SinkSpec.scala
@@ -251,6 +251,8 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec with Option
     val sseCSourceAlgorithmHeader = "x-amz-copy-source-server-side-encryption-customer-algorithm"
     val sseCSourceAlgorithmHeaderValue = "AES256"
     val sseCSourceKeyHeader = "x-amz-copy-source-server-side-encryption-customer-key"
+    val sseCKeyHeaderMd5 = "x-amz-server-side-encryption-customer-key-MD5"
+    val sseCKeyHeaderMd5Value = "md5"
     val sseCSourceKeyHeaderValue = sseCustomerKey
 
     val result =
@@ -286,10 +288,13 @@ class S3SinkSpec extends S3WireMockBase with S3ClientIntegrationSpec with Option
         .withHeader(sseCSourceKeyHeader, new EqualToPattern(sseCSourceKeyHeaderValue))
         .withHeader(requestPayerHeader, new EqualToPattern(requestPayerHeaderValue)))
 
-    // No SSE-C headers required for CompleteMultipartUpload
+    // SSE headers only
     mock.verifyThat(
       postRequestedFor(urlEqualTo(s"/$targetBucketKey?uploadId=$uploadId"))
-        .withHeader(requestPayerHeader, new EqualToPattern(requestPayerHeaderValue)))
+        .withHeader(sseCAlgorithmHeader, new EqualToPattern(sseCAlgorithmHeaderValue))
+        .withHeader(sseCKeyHeader, new EqualToPattern(sseCKeyHeaderValue))
+        .withHeader(sseCKeyHeaderMd5, new EqualToPattern(sseCKeyHeaderMd5Value))
+        .withoutHeader(requestPayerHeader))
 
   }
 


### PR DESCRIPTION
This PR fixes https://github.com/akka/alpakka/issues/2906, Alpakka created a regression whereby their latest Alpakka BSL release (4.0.0) has multipart upload broken.

According to S3 docs (see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html#API_CompleteMultipartUpload_Examples), you are not allowed to have any other headers that is not SSE related.

I tested this on my companies S3 account and I can confirm that it passes.