### PR TITLE
Set contentCount values to 0

### DIFF
--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
@@ -100,8 +100,8 @@ trait S3IntegrationSpec
       _.withCredentialsProvider(
         StaticCredentialsProvider.create(AwsBasicCredentials.create("invalid", "invalid"))))
 
-  def defaultRegionContentCount = 4
-  def otherRegionContentCount = 5
+  def defaultRegionContentCount = 0
+  def otherRegionContentCount = 0
 
   it should "list buckets in current aws account" in {
     val result = for {
@@ -1043,9 +1043,6 @@ class MinioS3IntegrationSpec
     extends TestKit(ActorSystem("MinioS3IntegrationSpec"))
     with S3IntegrationSpec
     with MinioS3Test {
-
-  override val defaultRegionContentCount = 0
-  override val otherRegionContentCount = 0
 
   override lazy val defaultS3Settings: S3Settings = s3Settings
     .withS3RegionProvider(


### PR DESCRIPTION
The fact that these values are set to 4 and 5 in the base test trait is likely complete oversight. For some context, these values are used in the `list with real credentials`, `list with real credentials using the Version 1 API`  and `list with real credentials in non us-east-1 zone` tests. In all of these cases, these are the first tests to run in the test suite and when they do run the buckets are empty which is why 0 is the correct value.

These tests were passing as expected in Minio since they were overridden to be 0 but they were failing in AWS S3.