### PR TITLE
Add S3 put plus get bucketWithVersioning API

### DIFF
--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/Marshalling.scala
@@ -32,6 +32,19 @@ import scala.xml.NodeSeq
 @InternalApi private[impl] object Marshalling {
   import ScalaXmlSupport._
 
+  implicit val bucketVersioningUnmarshaller: FromEntityUnmarshaller[BucketVersioningResult] = {
+    nodeSeqUnmarshaller(MediaTypes.`application/xml`, ContentTypes.`application/octet-stream`).map {
+      case NodeSeq.Empty => throw Unmarshaller.NoContentException
+      case x =>
+        val status = (x \ "Status").headOption.map(_.text match {
+          case "Enabled"   => BucketVersioningStatus.Enabled
+          case "Suspended" => BucketVersioningStatus.Suspended
+        })
+        val MFADelete = (x \ "MfaDelete").headOption.map(_.exists(_.text == "Enabled"))
+        BucketVersioningResult(status, MFADelete)
+    }
+  }
+
   implicit val multipartUploadUnmarshaller: FromEntityUnmarshaller[MultipartUpload] = {
     nodeSeqUnmarshaller(MediaTypes.`application/xml`, ContentTypes.`application/octet-stream`).map {
       case NodeSeq.Empty => throw Unmarshaller.NoContentException

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Request.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Request.scala
@@ -74,3 +74,13 @@ import org.apache.pekko.annotation.InternalApi
  * Internal Api
  */
 @InternalApi private[s3] case object CheckBucket extends S3Request
+
+/**
+ * Internal Api
+ */
+@InternalApi private[s3] case object PutBucketVersioning extends S3Request
+
+/**
+ * Internal Api
+ */
+@InternalApi private[s3] case object GetBucketVersioning extends S3Request

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
@@ -1633,4 +1633,124 @@ object S3 {
   private def func[T, R](f: T => R) = new pekko.japi.function.Function[T, R] {
     override def apply(param: T): R = f(param)
   }
+
+  /**
+   * Sets the versioning state of an existing bucket.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html
+   * @param bucketName       Bucket name
+   * @param bucketVersioning The state that you want to update
+   * @return [[java.util.concurrent.CompletionStage CompletionStage]] of type [[Done]] as API doesn't return any additional information
+   */
+  def putBucketVersioning(bucketName: String, bucketVersioning: BucketVersioning)(
+      implicit system: ClassicActorSystemProvider,
+      attributes: Attributes = Attributes()): CompletionStage[Done] =
+    putBucketVersioning(bucketName, bucketVersioning, S3Headers.empty)
+
+  /**
+   * Sets the versioning state of an existing bucket.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html
+   * @param bucketName       Bucket name
+   * @param bucketVersioning The state that you want to update
+   * @param s3Headers  any headers you want to add
+   * @return [[java.util.concurrent.CompletionStage CompletionStage]] of type [[Done]] as API doesn't return any additional information
+   */
+  def putBucketVersioning(
+      bucketName: String,
+      bucketVersioning: BucketVersioning,
+      s3Headers: S3Headers)(
+      implicit system: ClassicActorSystemProvider, attributes: Attributes): CompletionStage[Done] =
+    S3Stream
+      .putBucketVersioning(bucketName, bucketVersioning, s3Headers)(SystemMaterializer(system).materializer, attributes)
+      .toJava
+
+  /**
+   * Sets the versioning state of an existing bucket.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html
+   * @param bucketName       Bucket name
+   * @param bucketVersioning The state that you want to update
+   * @return [[pekko.stream.javadsl.Source Source]] of type [[Done]] as API doesn't return any additional information
+   */
+  def putBucketVersioningSource(bucketName: String, bucketVersioning: BucketVersioning): Source[Done, NotUsed] =
+    putBucketVersioningSource(bucketName, bucketVersioning, S3Headers.empty)
+
+  /**
+   * Sets the versioning state of an existing bucket.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html
+   * @param bucketName       Bucket name
+   * @param bucketVersioning The state that you want to update
+   * @param s3Headers  any headers you want to add
+   * @return [[pekko.stream.javadsl.Source Source]] of type [[Done]] as API doesn't return any additional information
+   */
+  def putBucketVersioningSource(bucketName: String,
+      bucketVersioning: BucketVersioning,
+      s3Headers: S3Headers): Source[Done, NotUsed] =
+    S3Stream.putBucketVersioningSource(bucketName, bucketVersioning, s3Headers).asJava
+
+  /**
+   * Gets the versioning of an existing bucket
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html
+   * @param bucketName Bucket name
+   * @param system     the actor system which provides the materializer to run with
+   * @param attributes attributes to run request with
+   * @return [[java.util.concurrent.CompletionStage CompletionStage]] of type [[BucketVersioningResult]]
+   */
+  def getBucketVersioning(bucketName: String,
+      system: ClassicActorSystemProvider,
+      attributes: Attributes): CompletionStage[BucketVersioningResult] =
+    getBucketVersioning(bucketName, system, attributes, S3Headers.empty)
+
+  /**
+   * Gets the versioning of an existing bucket
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html
+   * @param bucketName Bucket name
+   * @param system     the actor system which provides the materializer to run with
+   * @param attributes attributes to run request with
+   * @param s3Headers  any headers you want to add
+   * @return [[java.util.concurrent.CompletionStage CompletionStage]] of type [[BucketVersioningResult]]
+   */
+  def getBucketVersioning(bucketName: String,
+      system: ClassicActorSystemProvider,
+      attributes: Attributes,
+      s3Headers: S3Headers): CompletionStage[BucketVersioningResult] =
+    S3Stream.getBucketVersioning(bucketName, s3Headers)(SystemMaterializer(system).materializer, attributes).toJava
+
+  /**
+   * Gets the versioning of an existing bucket
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html
+   * @param bucketName Bucket name
+   * @param system     the actor system which provides the materializer to run with
+   * @return [[java.util.concurrent.CompletionStage CompletionStage]] of type [[BucketVersioningResult]]
+   */
+  def getBucketVersioning(
+      bucketName: String, system: ClassicActorSystemProvider): CompletionStage[BucketVersioningResult] =
+    getBucketVersioning(bucketName, system, Attributes(), S3Headers.empty)
+
+  /**
+   * Gets the versioning of an existing bucket
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html
+   * @param bucketName Bucket name
+   * @return [[pekko.stream.javadsl.Source Source]] of type [[BucketVersioningResult]]
+   */
+  def getBucketVersioningSource(bucketName: String): Source[BucketVersioningResult, NotUsed] =
+    getBucketVersioningSource(bucketName, S3Headers.empty)
+
+  /**
+   * Gets the versioning of an existing bucket
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html
+   * @param bucketName Bucket name
+   * @param s3Headers  any headers you want to add
+   * @return [[pekko.stream.javadsl.Source Source]] of type [[BucketVersioningResult]]
+   */
+  def getBucketVersioningSource(bucketName: String, s3Headers: S3Headers): Source[BucketVersioningResult, NotUsed] =
+    S3Stream.getBucketVersioningSource(bucketName, s3Headers).asJava
+
 }

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/model.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/model.scala
@@ -26,6 +26,219 @@ import scala.collection.immutable.Seq
 import scala.collection.immutable
 import scala.compat.java8.OptionConverters._
 
+final class MFA private (val serialNumber: String, val tokenCode: String) {
+
+  /** Java API */
+  def getSerialNumber: String = serialNumber
+
+  /** Java API */
+  def getTokenCode: String = tokenCode
+
+  def withSerialNumber(value: String): MFA = copy(serialNumber = value)
+
+  def withTokenCode(value: String): MFA = copy(tokenCode = value)
+
+  private def copy(serialNumber: String = serialNumber, tokenCode: String = tokenCode): MFA =
+    new MFA(
+      serialNumber,
+      tokenCode)
+
+  override def toString: String =
+    "MFA(" +
+    s"serialNumber=$serialNumber," +
+    s"tokenCode=$tokenCode" +
+    ")"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: MFA =>
+      Objects.equals(this.serialNumber, that.serialNumber) &&
+      Objects.equals(this.tokenCode, that.tokenCode)
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    Objects.hash(this.serialNumber, this.tokenCode)
+}
+
+object MFA {
+
+  /** Scala API */
+  def apply(serialNumber: String, tokenCode: String): MFA =
+    new MFA(serialNumber, tokenCode)
+
+  /** Java API */
+  def create(serialNumber: String, tokenCode: String): MFA =
+    apply(serialNumber, tokenCode)
+}
+
+sealed trait MFAStatus
+
+object MFAStatus {
+  final class Enabled private (val mfa: MFA) extends MFAStatus {
+
+    /** Java API */
+    def getMfa: MFA = mfa
+
+    // Warning is only being generated here because there is a single argument in the parameter list. If more fields
+    // get added to CommonPrefixes then the `@nowarn` is no longer needed
+    @nowarn
+    def withMfa(value: MFA): Enabled = copy(mfa = value)
+
+    private def copy(mfa: MFA): Enabled = new Enabled(mfa)
+
+    override def toString: String =
+      "Enabled(" +
+      s"mfa=$mfa" +
+      ")"
+
+    override def equals(other: Any): Boolean = other match {
+      case that: Enabled =>
+        Objects.equals(this.mfa, that.mfa)
+      case _ => false
+    }
+
+    override def hashCode(): Int = Objects.hash(this.mfa)
+
+  }
+
+  object Enabled {
+
+    /** Scala API */
+    def apply(mfa: MFA): Enabled = new Enabled(mfa)
+
+    /** Java API */
+    def create(mfa: MFA): Enabled = apply(mfa)
+  }
+
+  case object Disabled extends MFAStatus
+
+  /** Java API */
+  val disabled = Disabled
+
+}
+
+sealed trait BucketVersioningStatus
+
+object BucketVersioningStatus {
+  case object Enabled extends BucketVersioningStatus
+
+  case object Suspended extends BucketVersioningStatus
+
+  /** Java API */
+  val enabled = Enabled
+
+  /** Java API */
+  val suspended = Suspended
+}
+
+final class BucketVersioningResult private (val status: Option[BucketVersioningStatus],
+    val mfaDelete: Option[Boolean]) {
+
+  /** Java API */
+  def getStatus: Option[BucketVersioningStatus] = status
+
+  /** Java API */
+  def getMfaDelete: java.util.Optional[Boolean] = mfaDelete.asJava
+
+  def withStatus(value: BucketVersioningStatus): BucketVersioningResult =
+    copy(status = Some(value))
+
+  def withMfaDelete(value: Boolean): BucketVersioningResult =
+    copy(mfaDelete = Some(value))
+
+  private def copy(
+      status: Option[BucketVersioningStatus] = status, mfaDelete: Option[Boolean] = mfaDelete): BucketVersioningResult =
+    new BucketVersioningResult(
+      status,
+      mfaDelete)
+
+  override def toString: String =
+    "BucketVersioningResult(" +
+    s"status=$status," +
+    s"mfaDelete=$mfaDelete" +
+    ")"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: BucketVersioningResult =>
+      Objects.equals(this.status, that.status) &&
+      Objects.equals(this.mfaDelete, that.mfaDelete)
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    Objects.hash(this.status, this.mfaDelete)
+}
+
+object BucketVersioningResult {
+
+  def apply(): BucketVersioningResult = apply(None, None)
+
+  /** Scala API */
+  def apply(status: Option[BucketVersioningStatus], mfaDelete: Option[Boolean]): BucketVersioningResult =
+    new BucketVersioningResult(status, mfaDelete)
+
+  /** Java API */
+  def create(): BucketVersioningResult = apply()
+
+  def create(status: java.util.Optional[BucketVersioningStatus], mfaDelete: java.util.Optional[Boolean])
+      : BucketVersioningResult =
+    apply(status.asScala, mfaDelete.asScala)
+
+}
+
+final class BucketVersioning private (val status: Option[BucketVersioningStatus], val mfaDelete: Option[MFAStatus]) {
+
+  /** Java API */
+  def getStatus: java.util.Optional[BucketVersioningStatus] = status.asJava
+
+  /** Java API */
+  def getMfaDelete: java.util.Optional[MFAStatus] = mfaDelete.asJava
+
+  def withStatus(value: BucketVersioningStatus): BucketVersioning = copy(status = Some(value))
+
+  def withMfaDelete(value: MFAStatus): BucketVersioning = copy(mfaDelete = Some(value))
+
+  private def copy(
+      status: Option[BucketVersioningStatus] = status, mfaDelete: Option[MFAStatus] = mfaDelete): BucketVersioning =
+    new BucketVersioning(
+      status,
+      mfaDelete)
+
+  override def toString: String =
+    "BucketVersioning(" +
+    s"status=$status," +
+    s"mfaDelete=$mfaDelete" +
+    ")"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: BucketVersioning =>
+      Objects.equals(this.status, that.status) &&
+      Objects.equals(this.mfaDelete, that.mfaDelete)
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    Objects.hash(this.status, this.mfaDelete)
+}
+
+object BucketVersioning {
+
+  /** Scala API */
+  def apply(): BucketVersioning = apply(None, None)
+
+  /** Scala API */
+  def apply(status: Option[BucketVersioningStatus], mfaDelete: Option[MFAStatus]): BucketVersioning =
+    new BucketVersioning(status, mfaDelete)
+
+  /** Java API */
+  def create(): BucketVersioning = apply()
+
+  def create(
+      status: java.util.Optional[BucketVersioningStatus], mfaDelete: java.util.Optional[MFAStatus]): BucketVersioning =
+    apply(status.asScala, mfaDelete.asScala)
+
+}
+
 final class MultipartUpload private (val bucket: String, val key: String, val uploadId: String) {
 
   /** Java API */

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3.scala
@@ -1092,4 +1092,103 @@ object S3 {
       uploadId: String,
       s3Headers: S3Headers): Source[Done, NotUsed] =
     S3Stream.deleteUploadSource(bucketName, key, uploadId, s3Headers)
+
+  /**
+   * Sets the versioning state of an existing bucket.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html
+   * @param bucketName Bucket name
+   * @param bucketVersioning The state that you want to update
+   * @return [[scala.concurrent.Future Future]] of type [[Done]] as API doesn't return any additional information
+   */
+  def putBucketVersioning(bucketName: String, bucketVersioning: BucketVersioning)(
+      implicit system: ClassicActorSystemProvider,
+      attributes: Attributes = Attributes()): Future[Done] =
+    putBucketVersioning(bucketName, bucketVersioning, S3Headers.empty)
+
+  /**
+   * Sets the versioning state of an existing bucket.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html
+   * @param bucketName Bucket name
+   * @param bucketVersioning The state that you want to update
+   * @param s3Headers  any headers you want to add
+   * @return [[scala.concurrent.Future Future]] of type [[Done]] as API doesn't return any additional information
+   */
+  def putBucketVersioning(
+      bucketName: String,
+      bucketVersioning: BucketVersioning,
+      s3Headers: S3Headers)(implicit system: ClassicActorSystemProvider, attributes: Attributes): Future[Done] =
+    S3Stream.putBucketVersioning(bucketName, bucketVersioning, s3Headers)
+
+  /**
+   * Delete all existing parts for a specific upload
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html
+   * @param bucketName Bucket name
+   * @param bucketVersioning The state that you want to update
+   * @return [[pekko.stream.scaladsl.Source Source]] of type [[Done]] as API doesn't return any additional information
+   */
+  def putBucketVersioningSource(bucketName: String, bucketVersioning: BucketVersioning): Source[Done, NotUsed] =
+    putBucketVersioningSource(bucketName, bucketVersioning, S3Headers.empty)
+
+  /**
+   * Sets the versioning state of an existing bucket.
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html
+   * @param bucketName Bucket name
+   * @param bucketVersioning The state that you want to update
+   * @param s3Headers  any headers you want to add
+   * @return [[pekko.stream.scaladsl.Source Source]] of type [[Done]] as API doesn't return any additional information
+   */
+  def putBucketVersioningSource(bucketName: String,
+      bucketVersioning: BucketVersioning,
+      s3Headers: S3Headers): Source[Done, NotUsed] =
+    S3Stream.putBucketVersioningSource(bucketName, bucketVersioning, s3Headers)
+
+  /**
+   * Gets the versioning of an existing bucket
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html
+   * @param bucketName Bucket name
+   * @return [[scala.concurrent.Future Future]] of type [[BucketVersioningResult]]
+   */
+  def getBucketVersioning(bucketName: String)(implicit system: ClassicActorSystemProvider,
+      attributes: Attributes = Attributes()): Future[BucketVersioningResult] =
+    S3Stream.getBucketVersioning(bucketName, S3Headers.empty)
+
+  /**
+   * Gets the versioning of an existing bucket
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html
+   * @param bucketName Bucket name
+   * @param s3Headers  any headers you want to add
+   * @return [[scala.concurrent.Future Future]] of type [[BucketVersioningResult]]
+   */
+  def getBucketVersioning(
+      bucketName: String,
+      s3Headers: S3Headers)(
+      implicit system: ClassicActorSystemProvider, attributes: Attributes): Future[BucketVersioningResult] =
+    S3Stream.getBucketVersioning(bucketName, s3Headers)
+
+  /**
+   * Gets the versioning of an existing bucket
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html
+   * @param bucketName Bucket name
+   * @return [[pekko.stream.scaladsl.Source Source]] of type [[BucketVersioningResult]]
+   */
+  def getBucketVersioningSource(bucketName: String): Source[BucketVersioningResult, NotUsed] =
+    getBucketVersioningSource(bucketName, S3Headers.empty)
+
+  /**
+   * Gets the versioning of an existing bucket
+   *
+   * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html
+   * @param bucketName Bucket name
+   * @param s3Headers  any headers you want to add
+   * @return [[pekko.stream.scaladsl.Source Source]] of type [[BucketVersioningResult]]
+   */
+  def getBucketVersioningSource(bucketName: String, s3Headers: S3Headers): Source[BucketVersioningResult, NotUsed] =
+    S3Stream.getBucketVersioningSource(bucketName, s3Headers)
 }

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/impl/HttpRequestsSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/impl/HttpRequestsSpec.scala
@@ -500,4 +500,19 @@ class HttpRequestsSpec extends AnyFlatSpec with Matchers with ScalaFutures with 
     request.uri.queryString() should equal(None)
     request.method should equal(HttpMethods.HEAD)
   }
+
+  it should "add x-amz-mfa headers for a putBucketVersioning request" in {
+    implicit val settings: S3Settings = getSettings()
+
+    val serialNumber = "serial-number"
+    val tokenCode = "token-code"
+
+    val request: HttpRequest = HttpRequests.bucketVersioningRequest("target-bucket",
+      Some(MFAStatus.Enabled(MFA(serialNumber, tokenCode))),
+      HttpMethods.PUT)
+
+    request.headers.collectFirst {
+      case httpHeader if httpHeader.is("x-amz-mfa") => httpHeader.value()
+    } should equal(Some(s"$serialNumber $tokenCode"))
+  }
 }


### PR DESCRIPTION
So the context behind this PR is that I am trying to get integration tests working against the real AWS S3 (see https://github.com/apache/incubator-pekko-connectors/issues/67) and as part of that integration I am implementing the ability of the test suite to dynamically create/delete buckets (to prevent flaky test issues as a result of concurrency/left over state). In that work I ended up realizing that in order to get some of the tests to work I have to create buckets with versioning hence why I am making this PR.

Slightly annoyingly, the API of https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html / https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html has some unique peculiarities which made it harder to model. For starters the API differentiates between the versioning status of a bucket never being set versus it being set to false, alongside that there is an MFA field which is also part of the request hence why I modelled it. There are integration tests that verify this behaviour (tested on my companies AWS account) however since its highly impractical to test MFA I just ended up writing a unit test to make sure the headers are being correctly set (see `"add x-amz-mfa headers for a putBucketVersioning request"`).

There are some important design decisions which should be considered that I am definitely open to changing, i.e. both the `status` and `mfaDelete` fields are being modelled with an ADT rather than a `Boolean`. This is because the `status` field doesn't appear to be a true boolean (its `Enabled`/`Suspended` rather than just `Enabled`/`Disabled`) which means there is a chance that more fields can be added and also because of what was mentioned before wrt to the API explicitly modelling the case where a field is never set vs it being set to false you would end up with `Option[Boolean]` which isn't the nicest. There is however an exception to this which is `BucketVersioningResult.mfaField` which does contain `Option[Boolean]`. This is because when setting the status field via put you have to provide actual MFA details where as when you retrieve the status via a get result its just telling whether its never being set/enabled/disabled. If I wanted to model this I would have to create an entirely separate ADT just for that `Boolean` like value since `MFAStatus` is already being used for the put request and I didn't want to create so many types for what is largely going to be a case that most people won't care about.