### PR TITLE
Add bucketVersioningEnabled helper methods

### DIFF
--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/model.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/model.scala
@@ -146,6 +146,12 @@ final class BucketVersioningResult private (val status: Option[BucketVersioningS
   def withMfaDelete(value: Boolean): BucketVersioningResult =
     copy(mfaDelete = Some(value))
 
+  /** Java API */
+  def getBucketVersioningEnabled: Boolean = bucketVersioningEnabled
+
+  /** Scala API */
+  def bucketVersioningEnabled: Boolean = status.contains(BucketVersioningStatus.Enabled)
+
   private def copy(
       status: Option[BucketVersioningStatus] = status, mfaDelete: Option[Boolean] = mfaDelete): BucketVersioningResult =
     new BucketVersioningResult(
@@ -193,6 +199,12 @@ final class BucketVersioning private (val status: Option[BucketVersioningStatus]
 
   /** Java API */
   def getMfaDelete: java.util.Optional[MFAStatus] = mfaDelete.asJava
+
+  /** Java API */
+  def getBucketVersioningEnabled: Boolean = bucketVersioningEnabled
+
+  /** Scala API */
+  def bucketVersioningEnabled: Boolean = status.contains(BucketVersioningStatus.Enabled)
 
   def withStatus(value: BucketVersioningStatus): BucketVersioning = copy(status = Some(value))
 

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
@@ -843,7 +843,9 @@ trait S3IntegrationSpec
 
     whenReady(request) { case (firstValue, secondValue) =>
       firstValue shouldEqual BucketVersioningResult()
+      firstValue.bucketVersioningEnabled shouldEqual false
       secondValue shouldEqual BucketVersioningResult().withStatus(BucketVersioningStatus.Enabled)
+      secondValue.bucketVersioningEnabled shouldEqual true
       S3.putBucketVersioning(bucketName,
         BucketVersioning().withStatus(BucketVersioningStatus.Suspended)).futureValue shouldBe Done
       S3.deleteBucket(bucketName).futureValue


### PR DESCRIPTION
Follow up on from https://github.com/apache/incubator-pekko-connectors/pull/84, one of the  common usecases for bucket versioning  is to figure out if its enabled/disabled and due to the current field being nested inside of an option with a custom ADT the helper methods are being added to trivialize the operation.

Note that a Java alias is being added since the rest of the models in S3 follow the `field`/`getField` for Scala/Java repsectively.