### PR TITLE
Fix broken GooglePubSubSpec tests

### DIFF
--- a/google-cloud-pub-sub/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/GooglePubSubSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/GooglePubSubSpec.scala
@@ -73,7 +73,7 @@ class GooglePubSubSpec
     val source = Source(List(request))
 
     when(mockHttpApi.isEmulated).thenReturn(false)
-    when(mockHttpApi.publish[Unit](topic = "topic1", parallelism = 1))
+    when(mockHttpApi.publish[Unit](topic = "topic1", parallelism = 1, None))
       .thenReturn(FlowWithContext[PublishRequest, Unit].map(_ => PublishResponse(Seq("id1"))))
 
     val flow = googlePubSub.publish(
@@ -91,7 +91,7 @@ class GooglePubSubSpec
     val source = Source(List((request, "correlationId")))
 
     when(mockHttpApi.isEmulated).thenReturn(false)
-    when(mockHttpApi.publish[String](topic = "topic1", parallelism = 1))
+    when(mockHttpApi.publish[String](topic = "topic1", parallelism = 1, None))
       .thenReturn(FlowWithContext[PublishRequest, String].map(_ => PublishResponse(Seq("id1"))))
 
     val flow = googlePubSub.publishWithContext[String](
@@ -111,7 +111,8 @@ class GooglePubSubSpec
       override def isEmulated: Boolean = true
 
       override def publish[T](topic: String,
-          parallelism: Int): FlowWithContext[PublishRequest, T, PublishResponse, T, NotUsed] =
+          parallelism: Int,
+          host: Option[String]): FlowWithContext[PublishRequest, T, PublishResponse, T, NotUsed] =
         FlowWithContext[PublishRequest, T].map(_ => PublishResponse(Seq("id2")))
     }
 


### PR DESCRIPTION
Resolves: https://github.com/apache/incubator-pekko-connectors/issues/47

Turns out the reason why the tests were failing is because at some point an overloaded method with the `host: Option[String]` parameter was added and its this specific overloaded method which is now being called in the auth tests and the mocks in the broken tests was pointing to the original non overloaded method. 