### PR TITLE
Fix dependency resolution with GoogleBigQueryStorage module

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -206,6 +206,7 @@ object Dependencies {
       "io.grpc" % "grpc-auth" % org.apache.pekko.grpc.gen.BuildInfo.grpcVersion, // ApacheV2
       "org.apache.pekko" %% "pekko-http-spray-json" % PekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-core" % PekkoHttpVersion,
+      "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
       "org.apache.pekko" %% "pekko-parsing" % PekkoHttpVersion,
       "org.apache.arrow" % "arrow-memory-netty" % "4.0.1" % Test,
       "org.apache.pekko" %% "pekko-discovery" % PekkoVersion) ++ Mockito)


### PR DESCRIPTION
This is likely a result of us not using the pekko/pekko-http versions correctly due to using snapshots but nevertheless its better to pin `pekko-http` to the same version as the other pekko-http artifacts

```
[info]   java.lang.IllegalStateException: You are using version 0.0.0+4338-c98db6bd-SNAPSHOT of Akka HTTP, but it appears you (perhaps indirectly) also depend on older versions of related artifacts. You can solve this by adding an explicit dependency on version 0.0.0+4338-c98db6bd-SNAPSHOT of the [pekko-http] artifacts to your project. Here's a complete collection of detected artifacts: (0.0.0+4298-26846a02-SNAPSHOT, [pekko-http]), (0.0.0+4338-c98db6bd-SNAPSHOT, [pekko-http-core, pekko-http-spray-json, pekko-parsing]). See also:
```