### PR TITLE
Increase timeout for failing mqtt-streaming tests

### DIFF
--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala
@@ -51,7 +51,7 @@ class MqttSessionSpec
   val log = LoggerFactory.getLogger(classOf[MqttSessionSpec])
 
   implicit val executionContext: ExecutionContext = system.dispatcher
-  implicit val timeout: Timeout = Timeout(3.seconds.dilated)
+  implicit val timeout: Timeout = Timeout(6.seconds.dilated)
 
   val settings = MqttSessionSettings()
 
@@ -1916,6 +1916,9 @@ class MqttSessionSpec
     }
 
     "produce a duplicate publish on the server given two client connections" in assertAllStagesStopped {
+      // longer patience needed since Akka 2.6
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(scaled(1.second), scaled(50.millis))
+
       val serverSession = ActorMqttServerSession(settings.withProducerPubAckRecTimeout(10.millis))
 
       val client1 = TestProbe()


### PR DESCRIPTION
```
[info] - should produce a duplicate publish on the server given two client connections *** FAILED *** (660 milliseconds)
[info]   A timeout occurred waiting for a future to complete. Waited 600 milliseconds. (MqttSessionSpec.scala:2045)
```

from https://github.com/apache/incubator-pekko-connectors/actions/runs/4864707370/jobs/8674075485?pr=92 .

Note that this timeout along with the comment is copied from already existing tests in this spec, specifically https://github.com/apache/incubator-pekko-connectors/blob/c487bc3113edf4c50721ff337b0a9b5cfb492edc/mqtt-streaming/src/test/scala/docs/scaladsl/MqttSessionSpec.scala#L521-L522 .

There are other reasons why the mqtt-streaming tests are flaky but this is one of the low hanging fruit reasons.