### PR TITLE
Increase expected message timeout for mqtt-streaming

### DIFF
--- a/mqtt-streaming/src/test/resources/application.conf
+++ b/mqtt-streaming/src/test/resources/application.conf
@@ -4,4 +4,6 @@ pekko {
   loggers = ["org.apache.pekko.event.slf4j.Slf4jLogger"]
   logging-filter = "org.apache.pekko.event.slf4j.Slf4jLoggingFilter"
   loglevel = "DEBUG"
+
+  test.single-expect-default = 6s
 }


### PR DESCRIPTION
Forgot to increase another type of timeout, i.e.

```
[info]   java.lang.AssertionError: assertion failed: timeout (3 seconds) during expectMsg while waiting for ByteString(50, 26, 0, 10, 115, 111, 109, 101, 45, 116, 111, 112, 105, 99, 0, 1, 115, 111, 109, 101, 45, 112, 97, 121, 108, 111, 97, 100)
```

Lets see if this helps