### PR TITLE
Increase huawei-push-kit test timeout

### DIFF
--- a/huawei-push-kit/src/test/scala/org/apache/pekko/stream/connectors/huawei/pushkit/impl/PushKitSenderSpec.scala
+++ b/huawei-push-kit/src/test/scala/org/apache/pekko/stream/connectors/huawei/pushkit/impl/PushKitSenderSpec.scala
@@ -51,7 +51,7 @@ class PushKitSenderSpec
     TestKit.shutdownActorSystem(system)
 
   implicit val defaultPatience =
-    PatienceConfig(timeout = 2.seconds, interval = 50.millis)
+    PatienceConfig(timeout = 6.seconds, interval = 50.millis)
 
   implicit val executionContext: ExecutionContext = system.dispatcher
 


### PR DESCRIPTION
See

```
[info] HmsSender
[info] - should call the api as the docs want to *** FAILED *** (3 seconds, 401 milliseconds)
[info]   java.util.concurrent.TimeoutException: Future timed out after [2 seconds]
```