### PR TITLE
Integrate AWSS3IntegrationSpec with S3 Account

### DIFF
--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -1,0 +1,36 @@
+name: Nightly Builds
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  integration-tests:
+    name: Pekko Connectors Integration tests
+    runs-on: ubuntu-20.04
+    if: github.repository == 'apache/incubator-pekko-connectors'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.4.0
+
+      - name: S3 Integration tests
+        run:  |-
+          sbt \
+          -Dpekko.connectors.s3.aws.credentials.provider=static \
+          -Dpekko.connectors.s3.aws.credentials.access-key-id=${{ secrets.AWS_ACCESS_KEY }} \
+          -Dpekko.connectors.s3.aws.credentials.secret-access-key=${{ secrets.AWS_SECRET_KEY }} \
+          + "s3/Test/runMain org.scalatest.tools.Runner -o -s org.apache.pekko.stream.connectors.s3.scaladsl.AWSS3IntegrationSpec"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,6 +33,19 @@ object Dependencies {
   val TestContainersScalaTestVersion = "0.40.3"
   val mockitoVersion = "4.2.0" // check even https://github.com/scalatest/scalatestplus-mockito/releases
   val hoverflyVersion = "0.14.1"
+  val scalaCheckVersion = "1.15.4"
+
+  /**
+   * Calculates the scalatest version in a format that is used for `org.scalatestplus` scalacheck artifacts
+   *
+   * @see
+   * https://www.scalatest.org/user_guide/property_based_testing
+   */
+  private def scalaTestPlusScalaCheckVersion(version: String) =
+    version.split('.').take(2).mkString("-")
+
+  val scalaTestScalaCheckArtifact = s"scalacheck-${scalaTestPlusScalaCheckVersion(scalaCheckVersion)}"
+  val scalaTestScalaCheckVersion = s"$ScalaTestVersion.0"
 
   val CouchbaseVersion = "2.7.16"
   val CouchbaseVersionForDocs = "2.7"
@@ -155,7 +168,7 @@ object Dependencies {
       ("org.apache.hadoop" % "hadoop-client" % "3.2.1" % Test).exclude("log4j", "log4j"), // Apache2
       ("org.apache.hadoop" % "hadoop-common" % "3.2.1" % Test).exclude("log4j", "log4j"), // Apache2
       "com.sksamuel.avro4s" %% "avro4s-core" % "3.0.9" % Test,
-      "org.scalacheck" %% "scalacheck" % "1.15.4" % Test,
+      "org.scalacheck" %% "scalacheck" % scalaCheckVersion % Test,
       "org.specs2" %% "specs2-core" % "4.8.3" % Test, // MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
       "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html
     ))
@@ -375,8 +388,10 @@ object Dependencies {
       "software.amazon.awssdk" % "auth" % AwsSdk2Version,
       // in-memory filesystem for file related tests
       "com.google.jimfs" % "jimfs" % "1.2" % Test, // ApacheV2
-      "com.github.tomakehurst" % "wiremock-jre8" % "2.32.0" % Test // ApacheV2
-    ))
+      "com.github.tomakehurst" % "wiremock-jre8" % "2.32.0" % Test, // ApacheV2
+      "org.scalacheck" %% "scalacheck" % scalaCheckVersion % Test,
+      "org.scalatestplus" %% scalaTestScalaCheckArtifact % scalaTestScalaCheckVersion % Test,
+      "com.markatta" %% "futiles" % "2.0.2" % Test))
 
   val SpringWeb = {
     val SpringVersion = "5.1.17.RELEASE"

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/TestUtils.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/TestUtils.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package org.apache.pekko.stream.connectors.s3
+
+import markatta.futiles.Retry
+import org.apache.commons.lang3.StringUtils
+import org.apache.pekko
+import org.apache.pekko.stream.connectors.s3.scaladsl.S3
+import org.apache.pekko.stream.scaladsl.Sink
+import org.scalacheck.Gen
+import pekko.actor.ActorSystem
+import pekko.stream.Attributes
+
+import scala.annotation.tailrec
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Future }
+
+object TestUtils {
+  def checkEnvVarAvailable(env: String): Boolean =
+    try
+      sys.env.get(env) match {
+        case Some(value) if StringUtils.isBlank(value) => false
+        case Some(_)                                   => true
+        case None                                      => false
+      }
+    catch {
+      case _: NoSuchElementException => false
+    }
+
+  def cleanAndDeleteBucket(bucket: String, s3Attrs: Attributes)(implicit system: ActorSystem): Future[Unit] = {
+    implicit val ec: ExecutionContext = system.dispatcher
+    for {
+      bucketVersioningResult <- S3.getBucketVersioning(bucket)(implicitly, s3Attrs)
+      deleteAllVersions = bucketVersioningResult.status.contains(BucketVersioningStatus.Enabled)
+      _ <- S3.deleteBucketContents(bucket, deleteAllVersions = deleteAllVersions).withAttributes(s3Attrs).runWith(
+        Sink.ignore)
+      multiParts <-
+        S3.listMultipartUpload(bucket, None).withAttributes(s3Attrs).runWith(Sink.seq)
+      _ <- Future.sequence(multiParts.map { part =>
+        S3.deleteUpload(bucket, part.key, part.uploadId)(implicitly, s3Attrs)
+      })
+      _ <- Retry.retryWithBackOff(
+        5,
+        100.millis,
+        throwable => throwable.getMessage.contains("The bucket you tried to delete is not empty"))(
+        S3.deleteBucket(bucket)(implicitly, s3Attrs))
+      _ = system.log.info(s"Completed deleting bucket $bucket")
+    } yield ()
+  }
+
+  /**
+   * Will return a single value from a given generator. WARNING this will block the thread
+   * until a value is retrieved so only use this for generators that have a high chance of
+   * returning a value. If a [[Gen.filter]] ends up filtering out too many values this can
+   * cause the thread to be stuck for a long time
+   */
+  @tailrec
+  def loopUntilGenRetrievesValue[T](gen: Gen[T]): T =
+    gen.sample match {
+      case Some(value) => value
+      case None        => loopUntilGenRetrievesValue(gen)
+    }
+
+}

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/Generators.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/Generators.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package org.apache.pekko.stream.connectors.s3.scaladsl
+
+import org.scalacheck.Gen
+
+import scala.annotation.nowarn
+import scala.language.postfixOps
+object Generators {
+  val MaxBucketLength: Int = 63
+
+  // See https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html for valid
+  // bucketnames
+
+  lazy val bucketLetterOrNumberCharGen: Gen[Char] = Gen.frequency(
+    (1, Gen.numChar),
+    (1, Gen.alphaLowerChar))
+
+  def bucketAllCharGen(useVirtualDotHost: Boolean): Gen[Char] = {
+    val base = List(
+      (10, Gen.alphaLowerChar),
+      (1, Gen.const('-')),
+      (1, Gen.numChar))
+
+    val frequency = if (useVirtualDotHost) (1, Gen.const('.')) +: base else base
+
+    Gen.frequency(frequency: _*)
+  }
+
+  @nowarn("msg=not.*?exhaustive")
+  private def checkInvalidDuplicateChars(chars: List[Char]): Boolean =
+    chars.sliding(2).forall { case Seq(before, after) =>
+      !(before == '.' && after == '.' || before == '-' && after == '.' || before == '.' && after == '-')
+    }
+
+  private def checkAlphaChar(c: Char): Boolean =
+    c >= 'a' && c <= 'z'
+
+  private def allCharCheck(useVirtualDotHost: Boolean, string: String): Boolean =
+    if (useVirtualDotHost) {
+      string.forall(char => Character.isDigit(char) || checkAlphaChar(char) || char == '-' || char == '.') &&
+      checkInvalidDuplicateChars(string.toList)
+    } else
+      string.forall(char => Character.isDigit(char) || checkAlphaChar(char) || char == '-')
+
+  def validatePrefix(useVirtualDotHost: Boolean, prefix: Option[String]): Option[String] = {
+    val withoutWhitespace = prefix match {
+      case Some(value) if value.trim == "" => None
+      case Some(value)                     => Some(value)
+      case None                            => None
+    }
+
+    withoutWhitespace match {
+      case Some(value) if !(Character.isDigit(value.head) || checkAlphaChar(value.head)) =>
+        throw new IllegalArgumentException(
+          s"Invalid starting digit for prefix $value, ${value.head} needs to be an alpha char or digit")
+      case Some(value) if value.length > 1 =>
+        if (!allCharCheck(useVirtualDotHost, value.drop(1)))
+          throw new IllegalArgumentException(
+            s"Prefix $value contains invalid characters")
+      case Some(value) if value.length > MaxBucketLength - 1 =>
+        throw new IllegalArgumentException(
+          s"Prefix is too long, it has size ${value.length} where as the max bucket size is $MaxBucketLength")
+      case _ => ()
+    }
+
+    withoutWhitespace
+  }
+
+  def bucketNameGen(useVirtualDotHost: Boolean, prefix: Option[String] = None): Gen[String] = {
+    val finalPrefix = validatePrefix(useVirtualDotHost, prefix)
+
+    for {
+      range <- {
+        val maxLength = finalPrefix match {
+          case Some(p) => MaxBucketLength - p.length
+          case None    => MaxBucketLength
+        }
+
+        if (maxLength > 3)
+          Gen.choose(3, maxLength)
+        else
+          Gen.const(maxLength)
+      }
+      startString = finalPrefix.getOrElse("")
+
+      bucketName <- range match {
+        case 3 =>
+          for {
+            first <- bucketLetterOrNumberCharGen
+            second <- bucketAllCharGen(useVirtualDotHost)
+            third <- bucketLetterOrNumberCharGen
+          } yield startString ++ List(first, second, third).mkString
+        case _ =>
+          for {
+            first <- bucketLetterOrNumberCharGen
+            last <- bucketLetterOrNumberCharGen
+            middle <- {
+              val gen = Gen.listOfN(range - 2, bucketAllCharGen(useVirtualDotHost))
+              if (useVirtualDotHost) gen.filter(checkInvalidDuplicateChars) else gen
+            }
+          } yield startString ++ first.toString ++ middle.mkString ++ last.toString
+      }
+    } yield bucketName
+  }
+
+}


### PR DESCRIPTION
Resolves: https://github.com/apache/incubator-pekko-connectors/issues/67

Firstly before reviewing its recommended to change the diff to ignore whitespace i.e. 
![image](https://user-images.githubusercontent.com/2337269/235852521-98f7adf6-2c8a-4351-8dfd-25a00a323968.png)
as it will make it easier to review.

This PR is about modifying the `AWSS3IntegrationSpec` so that it can run in CI against a real AWS S3 account which Apache INFRA is supporting (see https://issues.apache.org/jira/browse/INFRA-24353). Initially the idea was to do this later, but considering that the Pekko/Akka S3 client unintentionally broke (see https://github.com/apache/incubator-pekko-connectors/pull/81) the importance of this was increased, i.e. we want to make sure that the S3 client actually works whenever a release is made.

Although the current `AWSS3IntegrationSpec` can currently run against a real S3 account it was intended to be tested manually (ergo not in CI) and hence its implementation was basic and not suitable for CI usage. This means the PR implements many features which is highly desired for running in CI, i.e. the ability for each test run to generate its own S3 buckets using randomly generated bucket names that contain a prefix (in this case `pekko-connectors`). This is so that multiple instances of `AWSS3IntegrationSpec` can be run at the same time without conflicting each other. Likewise the tests will also clean up the bucket after themselves and if this happens to fail then there will be a S3 lambda will do this automatically.

Note that this behaviour of randomly generating bucket names/cleaning up is only enabled for `AWSS3IntegrationSpec`, `MinioS3IntegrationSpec` behaves the same way as it did before (i.e. it uses static bucket names). This is due to the fact that `MinioS3IntegrationSpec` uses testcontainers and hence it will spawn a unique docker container for each test run. There is an argument that since we are randomly generating bucket names some of the behaviour is not really necessary (i.e. rather than dealing with static buckets for the entire test run we can alter the test suite so that every test generates the bucket it needs itself). This would reduce the complexity of the test suite but it would make the PR harder to review and its also not necessary right now.

One final thing to note is that the test is being run as a nightly job rather than in the usual CI that triggers on PR creation. This is due to both security reasons and practical reasons, i.e. as of now the AWS credentials are being stored as github secrets and github will only expose those secrets if the creator of the PR is a maintainer of the repo or on a cronjob trigger (this is to prevent malicious actors from just creating PR's that echo/print/send the secrets). While this problem is solvable in the sense that we can only run the `AWSS3IntegrationSpec` if the credentials are available (so that at least PR's created by maintainers runs the CI), this would add quite a lot of noise to the test due to the fact that its not possible to tag an entire test suite based on a condition (annotations only work with compile time constants).

The proper way to solve this problem is to use OIDC which also allows any PR creator to run full tests on S3 (OIDC works by creating temporary credentials that only last during CI run so even if a malicious actor steals the credentials, combined with the most restrictive set of AWS permissions its very difficult for them to actually compromise anything meaningful with them).