### PR TITLE
Don't run problematic tests in AWS S3 account

### DIFF
--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -33,4 +33,6 @@ jobs:
           -Dpekko.connectors.s3.aws.credentials.provider=static \
           -Dpekko.connectors.s3.aws.credentials.access-key-id=${{ secrets.AWS_ACCESS_KEY }} \
           -Dpekko.connectors.s3.aws.credentials.secret-access-key=${{ secrets.AWS_SECRET_KEY }} \
+          -Dpekko.stream.connectors.s3.scaladsl.AWSS3IntegrationSpec.enableListAllMyBucketsTests=false \
+          -Dpekko.stream.connectors.s3.scaladsl.AWSS3IntegrationSpec.enableMFATests=false \
           + "s3/Test/runMain org.scalatest.tools.Runner -o -s org.apache.pekko.stream.connectors.s3.scaladsl.AWSS3IntegrationSpec"

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
@@ -256,6 +256,11 @@ trait S3IntegrationSpec
   def otherRegionContentCount = 0
 
   it should "list buckets in current aws account" in withDefaultBucket { defaultBucket =>
+    assume((this.isInstanceOf[AWSS3IntegrationSpec], S3IntegrationSpec.AWSS3EnableListAllMyBucketsTests) match {
+      case (true, true)  => true
+      case (true, false) => false
+      case (false, _)    => true
+    })
     val result = for {
       buckets <- S3.listBuckets().withAttributes(attributes).runWith(Sink.seq)
     } yield buckets
@@ -266,6 +271,11 @@ trait S3IntegrationSpec
   }
 
   it should "list buckets in current AWS account using non US_EAST_1 region" in withDefaultBucket { defaultBucket =>
+    assume((this.isInstanceOf[AWSS3IntegrationSpec], S3IntegrationSpec.AWSS3EnableListAllMyBucketsTests) match {
+      case (true, true)  => true
+      case (true, false) => false
+      case (false, _)    => true
+    })
     // Its only AWS that complains if listBuckets is called from a non US_EAST_1 region
     val result = for {
       buckets <- S3.listBuckets().withAttributes(
@@ -1031,6 +1041,11 @@ trait S3IntegrationSpec
   }
 
   it should "enable and disable versioning for a bucket with MFA delete configured to false" in {
+    assume((this.isInstanceOf[AWSS3IntegrationSpec], S3IntegrationSpec.AWSS3EnableMFATests) match {
+      case (true, true)  => true
+      case (true, false) => false
+      case (false, _)    => true
+    })
     // TODO: Figure out a way to properly test this with Minio, see https://github.com/akka/alpakka/issues/2750
     assume(this.isInstanceOf[AWSS3IntegrationSpec])
     forAll(genBucketName("samplebucketversioningmfadeletefalse")) { bucketName =>
@@ -1321,4 +1336,12 @@ object S3IntegrationSpec {
   val DefaultBucket = "my-test-us-east-1"
   val BucketWithVersioning = "my-bucket-with-versioning"
   val NonExistingBucket = "nowhere"
+
+  val AWSS3EnableListAllMyBucketsTests =
+    sys.props.get("pekko.stream.connectors.s3.scaladsl.AWSS3IntegrationSpec.enableListAllMyBucketsTests")
+      .map(_.toBoolean).getOrElse(true)
+
+  val AWSS3EnableMFATests =
+    sys.props.get("pekko.stream.connectors.s3.scaladsl.AWSS3IntegrationSpec.enableMFATests")
+      .map(_.toBoolean).getOrElse(true)
 }


### PR DESCRIPTION
So if you follow the `#asfinra` slack discussion at https://the-asf.slack.com/archives/CBX4TSBQ8/p1683672460539449 we managed to get most of the AWS S3 tests passing in Apache's S3 account however a few of them turned out to be problematic (see https://github.com/apache/incubator-pekko-connectors/actions/runs/4931691903/jobs/8813985233 for more info). The problematic tests were ones that involved the `ListAllMyBuckets` call + MFA, which is difficult to get right with restricted permissions (necessary for security since this Apache S3 account is being used by others).

This PR makes tests that require these permissions to be configurable as well as disabling them in our nightly CI run. While it may be theoretically possible to come up with an IAM policy to test everything, I don't have capacity for this now and the current state is good enough