### PR TITLE
Add nightly builds badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Apache Pekko Connectors [![scaladex-badge][]][scaladex] [![maven-central-badge][]][maven-central] [![CI on GitHub actions](https://github.com/apache/incubator-pekko-connectors/actions/workflows/check-build-test.yml/badge.svg)](https://github.com/apache/incubator-pekko-connectors/actions/workflows/check-build-test.yml)
+Apache Pekko Connectors [![scaladex-badge][]][scaladex] [![maven-central-badge][]][maven-central] [![CI on GitHub actions](https://github.com/apache/incubator-pekko-connectors/actions/workflows/check-build-test.yml/badge.svg)](https://github.com/apache/incubator-pekko-connectors/actions/workflows/check-build-test.yml)[![Nightly Builds](https://github.com/apache/incubator-pekko-connectors/actions/workflows/nightly-builds.yaml/badge.svg)](https://github.com/apache/incubator-pekko-connectors/actions/workflows/nightly-builds.yaml)
 =======
 
 [scaladex]:              https://index.scala-lang.org/apache/incubator-pekko-connectors


### PR DESCRIPTION
Now that our nightly builds (currently S3 integration tests) are passing (see https://github.com/apache/incubator-pekko-connectors/actions/runs/4946076457) lets add a badge to illustrate this.