### PR TITLE
re-enable link-validator workflow

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -1,12 +1,13 @@
 name: Link Validator
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 6 * * 1'
 
 jobs:
   validate-links:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -28,6 +29,5 @@ jobs:
       - name: sbt site
         run: sbt docs/makeSite
 
-# TODO: Fix after documentation updates
-#      - name: Run Link Validator
-#        run: cs launch net.runne::site-link-validator:0.2.2 -- scripts/link-validator.conf
+      - name: Run Link Validator
+        run: cs launch net.runne::site-link-validator:0.2.2 -- scripts/link-validator.conf


### PR DESCRIPTION
* job runs weekly but fails - I think it's because of the old ubuntu version
* the workflow has been neutered - to not run the actual validations
* so this PR re-enables them