### PR TITLE
Update sbt-apache-sonatype and handle rename

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -15,7 +15,7 @@ import de.heikoseeberger.sbtheader._
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys._
 import com.lightbend.sbt.JavaFormatterPlugin.autoImport.javafmtOnCompile
 import com.typesafe.tools.mima.plugin.MimaKeys._
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
 import sbtdynver.DynVerPlugin
 import sbtdynver.DynVerPlugin.autoImport.dynverSonatypeSnapshots
 
@@ -28,7 +28,7 @@ object Common extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def requires = JvmPlugin && HeaderPlugin && SonatypeApachePlugin && DynVerPlugin
+  override def requires = JvmPlugin && HeaderPlugin && ApacheSonatypePlugin && DynVerPlugin
 
   override def globalSettings = Seq(
     scmInfo := Some(ScmInfo(url("https://github.com/apache/incubator-pekko-connectors"),

--- a/project/MetaInfLicenseNoticeCopy.scala
+++ b/project/MetaInfLicenseNoticeCopy.scala
@@ -9,8 +9,8 @@
 
 import sbt.Keys._
 import sbt._
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin.autoImport._
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin.autoImport._
 
 /**
  * Copies LICENSE and NOTICE files into jar META-INF dir
@@ -24,5 +24,5 @@ object MetaInfLicenseNoticeCopy extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def requires = SonatypeApachePlugin
+  override def requires = ApacheSonatypePlugin
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.6")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.7")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
 // discipline
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")


### PR DESCRIPTION
Updates sbt-apache-sonatype. Note that this new version renames `SonatypeApachePlugin` to `ApacheSonatypePlugin` to be consistent with the project name.