### PR TITLE
Unwrap single string interpolation syntax

### DIFF
--- a/amqp/src/test/scala/org/apache/pekko/stream/connectors/amqp/scaladsl/AmqpConnectorsSpec.scala
+++ b/amqp/src/test/scala/org/apache/pekko/stream/connectors/amqp/scaladsl/AmqpConnectorsSpec.scala
@@ -347,7 +347,7 @@ class AmqpConnectorsSpec extends AmqpSpec {
     }
 
     "set routing key per message and consume them in the same JVM" in assertAllStagesStopped {
-      def getRoutingKey(s: String) = s"key.${s}"
+      def getRoutingKey(s: String) = s"key.$s"
 
       val exchangeName = "amqp.topic." + System.currentTimeMillis()
       val queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis()

--- a/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
+++ b/azure-storage-queue/src/test/scala/docs/scaladsl/AzureQueueSpec.scala
@@ -66,7 +66,7 @@ class AzureQueueSpec extends TestKit(ActorSystem()) with AsyncFlatSpecLike with 
 
   private var testMsgCount = 0
   def queueTestMsg: CloudQueueMessage = {
-    val message = new CloudQueueMessage(s"Test message no. ${testMsgCount}")
+    val message = new CloudQueueMessage(s"Test message no. $testMsgCount")
     testMsgCount += 1
     message
   }

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -68,7 +68,7 @@ trait CopyrightHeader extends AutoPlugin {
         case Some(currentText) if isOnlyLightbendCopyrightAnnotated(currentText) =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText) + NewLine * 2 + currentText
         case Some(currentText) =>
-          throw new IllegalStateException(s"Unable to detect copyright for header: [${currentText}]")
+          throw new IllegalStateException(s"Unable to detect copyright for header: [$currentText]")
         case None =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText)
       }
@@ -86,7 +86,7 @@ trait CopyrightHeader extends AutoPlugin {
         case Some(currentText) if isOnlyLightbendCopyrightAnnotated(currentText) =>
           HeaderCommentStyle.hashLineComment.commentCreator(apacheSpdxHeader, existingText) + NewLine * 2 + currentText
         case Some(currentText) =>
-          throw new IllegalStateException(s"Unable to detect copyright for header: [${currentText}]")
+          throw new IllegalStateException(s"Unable to detect copyright for header: [$currentText]")
         case None =>
           HeaderCommentStyle.hashLineComment.commentCreator(apacheSpdxHeader, existingText)
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -366,7 +366,7 @@ object Dependencies {
     ))
 
   val PravegaVersion = "0.10.2"
-  val PravegaVersionForDocs = s"v${PravegaVersion}"
+  val PravegaVersionForDocs = s"v$PravegaVersion"
 
   val Pravega = {
     Seq(


### PR DESCRIPTION
Unwraps single string interpolation i.e. `s"${something}"` into `s"$something"`. Make sure to do a rebase merge of this PR because I need to add its commit to `.git-blame-ignore-revs`