### PR TITLE
upgrade logback

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,11 +66,10 @@ object Dependencies {
       "org.apache.pekko" %% "pekko-stream" % PekkoVersion,
       "org.apache.pekko" %% "pekko-stream-testkit" % PekkoVersion,
       "org.apache.pekko" %% "pekko-slf4j" % PekkoVersion,
-      "ch.qos.logback" % "logback-classic" % "1.2.3", // Eclipse Public License 1.0
+      "ch.qos.logback" % "logback-classic" % "1.2.11", // Eclipse Public License 1.0
       "org.scalatest" %% "scalatest" % ScalaTestVersion,
       "com.dimafeng" %% "testcontainers-scala-scalatest" % TestContainersScalaTestVersion,
       "com.novocode" % "junit-interface" % "0.11", // BSD-style
-      "ch.qos.logback" % "logback-classic" % "1.2.3", // Eclipse Public License 1.0
       "junit" % "junit" % "4.13" // Eclipse Public License 1.0
     ))
 


### PR DESCRIPTION
* testkit project is internal
* the logback-classic dependency is duplicated
* logback 1.2.11 is what we use in pekko core when testing
* there are CVEs in logback 1.2.3 -- see https://mvnrepository.com/artifact/ch.qos.logback/logback-classic/1.2.3 (transitive dependency on logback-core 1.2.3 is the issue)