### PR TITLE
fix issue with Scala 2.12 testing

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -157,7 +157,7 @@ jobs:
           PRE_CMD: ${{ matrix.pre_cmd }}
         run: |-
           $PRE_CMD
-          sbt +~2.12 "${CONNECTOR}/test"
+          sbt ++2.12.17 "${CONNECTOR}/test"
 
       - name: ${{ matrix.connector }} (scala 2.13)
         env:
@@ -165,7 +165,7 @@ jobs:
           PRE_CMD: ${{ matrix.pre_cmd }}
         run: |-
           $PRE_CMD
-          sbt +~2.13 "${CONNECTOR}/test"
+          sbt ++2.13.10 "${CONNECTOR}/test"
 
       - name: Print logs on failure
         if: failure()

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -151,21 +151,13 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: ${{ matrix.connector }} (scala 2.12)
+      - name: ${{ matrix.connector }}
         env:
           CONNECTOR: ${{ matrix.connector }}
           PRE_CMD: ${{ matrix.pre_cmd }}
         run: |-
           $PRE_CMD
-          sbt ++2.12.17 "${CONNECTOR}/test"
-
-      - name: ${{ matrix.connector }} (scala 2.13)
-        env:
-          CONNECTOR: ${{ matrix.connector }}
-          PRE_CMD: ${{ matrix.pre_cmd }}
-        run: |-
-          $PRE_CMD
-          sbt ++2.13.10 "${CONNECTOR}/test"
+          sbt "+${CONNECTOR}/test"
 
       - name: Print logs on failure
         if: failure()


### PR DESCRIPTION
I looked at https://github.com/apache/incubator-pekko-connectors/actions/runs/5114976247/jobs/9196215819?pr=121 and you can note that the Scala 2.12 tests are compiling to target/2.13.

I've changed the build files and using `++2.12.17` works as it should.