### PR TITLE
fix up deprecation versions so they refer to Alpakka

### DIFF
--- a/dynamodb/src/main/scala/org/apache/pekko/stream/connectors/dynamodb/javadsl/DynamoDb.scala
+++ b/dynamodb/src/main/scala/org/apache/pekko/stream/connectors/dynamodb/javadsl/DynamoDb.scala
@@ -81,9 +81,9 @@ object DynamoDb {
 
   /**
    * Create a CompletionStage that will be completed with a response to a given request.
-   * @deprecated pass in the actor system instead of the materializer, since 3.0.0
+   * @deprecated pass in the actor system instead of the materializer, since Alpakka 3.0.0
    */
-  @deprecated("pass in the actor system instead of the materializer", "3.0.0")
+  @deprecated("pass in the actor system instead of the materializer", "Alpakka 3.0.0")
   def single[In <: DynamoDbRequest, Out <: DynamoDbResponse](client: DynamoDbAsyncClient,
       operation: DynamoDbOp[In, Out],
       request: In,

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/ElasticsearchConnectionSettings.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/ElasticsearchConnectionSettings.scala
@@ -59,13 +59,13 @@ final class ElasticsearchConnectionSettings private (
   }
 
   /** Scala API */
-  @deprecated("prefer ElasticsearchConnectionSettings.withSSLContext", "3.1.0")
+  @deprecated("prefer ElasticsearchConnectionSettings.withSSLContext", "Alpakka 3.1.0")
   @Deprecated
   def withConnectionContext(connectionContext: HttpsConnectionContext): ElasticsearchConnectionSettings =
     copy(connectionContext = Option(connectionContext))
 
   /** Java API */
-  @deprecated("prefer ElasticsearchConnectionSettings.withSSLContext", "3.1.0")
+  @deprecated("prefer ElasticsearchConnectionSettings.withSSLContext", "Alpakka 3.1.0")
   @Deprecated
   def withConnectionContext(
       connectionContext: pekko.http.javadsl.HttpsConnectionContext): ElasticsearchConnectionSettings = {

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/javadsl/FtpApi.scala
@@ -213,7 +213,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { _: FtpSourceFactory[Ft
    * @param connectionSettings connection settings
    * @param materializer materializer
    * @return [[java.util.concurrent.CompletionStage CompletionStage]] of [[pekko.Done]] indicating a materialized, asynchronous request
-   * @deprecated pass in the actor system instead of the materializer, since 3.0.0
+   * @deprecated pass in the actor system instead of the materializer, since Alpakka 3.0.0
    */
   @Deprecated
   def mkdirAsync(basePath: String, name: String, connectionSettings: S, mat: Materializer): CompletionStage[Done]

--- a/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/PubSubSettings.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/PubSubSettings.scala
@@ -36,7 +36,7 @@ final class PubSubSettings private (
     /** @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]] */
     @deprecated(
       "Use org.apache.pekko.stream.connectors.google.GoogleSettings",
-      "3.0.0") @Deprecated val callCredentials: Option[
+      "Alpakka 3.0.0") @Deprecated val callCredentials: Option[
       CallCredentials]) {
 
   /**
@@ -60,7 +60,7 @@ final class PubSubSettings private (
    * Credentials that are going to be used for gRPC call authorization.
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
   @Deprecated
   def withCallCredentials(callCredentials: CallCredentials): PubSubSettings =
     copy(callCredentials = Some(callCredentials))

--- a/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/model.scala
+++ b/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/model.scala
@@ -33,10 +33,10 @@ class PubSubConfig private (
     /** @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]] */
     @deprecated(
       "Use org.apache.pekko.stream.connectors.google.GoogleSettings",
-      "3.0.0") @Deprecated val projectId: String,
+      "Alpakka 3.0.0") @Deprecated val projectId: String,
     val pullReturnImmediately: Boolean,
     val pullMaxMessagesPerInternalBatch: Int,
-    @deprecated("Added only to help with migration", "3.0.0") @InternalApi private[pubsub] val settings: Option[
+    @deprecated("Added only to help with migration", "Alpakka 3.0.0") @InternalApi private[pubsub] val settings: Option[
       GoogleSettings]) {
 
   override def toString: String =
@@ -58,7 +58,7 @@ object PubSubConfig {
   /**
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]] to manage credentials
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings to manage credentials", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings to manage credentials", "Alpakka 3.0.0")
   @Deprecated
   def apply(projectId: String, clientEmail: String, privateKey: String)(
       implicit actorSystem: ActorSystem): PubSubConfig =
@@ -76,7 +76,7 @@ object PubSubConfig {
   /**
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]] to manage credentials
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings to manage credentials", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings to manage credentials", "Alpakka 3.0.0")
   @Deprecated
   def apply(projectId: String,
       clientEmail: String,
@@ -99,7 +99,7 @@ object PubSubConfig {
    * Java API
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]] to manage credentials
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings to manage credentials", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings to manage credentials", "Alpakka 3.0.0")
   @Deprecated
   def create(projectId: String, clientEmail: String, privateKey: String, actorSystem: ActorSystem): PubSubConfig =
     apply(projectId, clientEmail, privateKey)(actorSystem)
@@ -108,7 +108,7 @@ object PubSubConfig {
    * Java API
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]] to manage credentials
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings to manage credentials", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings to manage credentials", "Alpakka 3.0.0")
   @Deprecated
   def create(projectId: String,
       clientEmail: String,

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageAttributes.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageAttributes.scala
@@ -21,7 +21,7 @@ import pekko.stream.Attributes.Attribute
  * Pekko Stream attributes that are used when materializing GCStorage stream blueprints.
  * @deprecated Use [[pekko.stream.connectors.google.GoogleAttributes]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleAttributes", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleAttributes", "Alpakka 3.0.0")
 @Deprecated
 object GCStorageAttributes {
 
@@ -39,14 +39,14 @@ object GCStorageAttributes {
 /**
  * @deprecated Use [[pekko.stream.connectors.google.GoogleAttributes]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleAttributes", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleAttributes", "Alpakka 3.0.0")
 @Deprecated
 final class GCStorageSettingsPath private (val path: String) extends Attribute
 
 /**
  * @deprecated Use [[pekko.stream.connectors.google.GoogleAttributes]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleAttributes", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleAttributes", "Alpakka 3.0.0")
 @Deprecated
 object GCStorageSettingsPath {
   val Default = GCStorageSettingsPath(GCStorageSettings.ConfigPath)
@@ -57,14 +57,14 @@ object GCStorageSettingsPath {
 /**
  * @deprecated Use [[pekko.stream.connectors.google.GoogleAttributes]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleAttributes", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleAttributes", "Alpakka 3.0.0")
 @Deprecated
 final class GCStorageSettingsValue private (val settings: GCStorageSettings) extends Attribute
 
 /**
  * @deprecated Use [[pekko.stream.connectors.google.GoogleAttributes]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleAttributes", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleAttributes", "Alpakka 3.0.0")
 @Deprecated
 object GCStorageSettingsValue {
   def apply(settings: GCStorageSettings) = new GCStorageSettingsValue(settings)

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageExt.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageExt.scala
@@ -20,7 +20,7 @@ import pekko.actor.{ ClassicActorSystemProvider, ExtendedActorSystem, Extension,
  * Manages one [[GCStorageSettings]] per `ActorSystem`.
  * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]].
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
 @Deprecated
 final class GCStorageExt private (sys: ExtendedActorSystem) extends Extension {
   val settings: GCStorageSettings = settings(GCStorageSettings.ConfigPath)
@@ -31,7 +31,7 @@ final class GCStorageExt private (sys: ExtendedActorSystem) extends Extension {
 /**
  * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
 @Deprecated
 object GCStorageExt extends ExtensionId[GCStorageExt] with ExtensionIdProvider {
   override def lookup = GCStorageExt

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageSettings.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/GCStorageSettings.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.Config
 /**
  * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
 @Deprecated
 final class GCStorageSettings private (
     val projectId: String,
@@ -106,7 +106,7 @@ final class GCStorageSettings private (
 /**
  * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
 @Deprecated
 object GCStorageSettings {
   val ConfigPath = "pekko.connectors.google.cloud.storage"

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/StorageSettings.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/StorageSettings.scala
@@ -16,7 +16,7 @@ package org.apache.pekko.stream.connectors.googlecloud.storage
 /**
  * @deprecated Use [[org.apache.pekko.stream.connectors.google.GoogleSettings]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
 @Deprecated
 final class StorageSettings private (val projectId: String, val clientEmail: String, val privateKey: String) {
   def withProjectId(projectId: String): StorageSettings = copy(projectId = projectId)
@@ -37,7 +37,7 @@ final class StorageSettings private (val projectId: String, val clientEmail: Str
 /**
  * @deprecated Use [[org.apache.pekko.stream.connectors.google.GoogleSettings]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
 @Deprecated
 object StorageSettings {
   def apply(projectId: String, clientEmail: String, privateKey: String): StorageSettings =

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/javadsl/GCStorage.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/javadsl/GCStorage.scala
@@ -46,9 +46,9 @@ object GCStorage {
    * @param materializer materializer to run with
    * @param attributes attributes to run request with
    * @return a `CompletionStage` containing `Bucket` if it exists
-   * @deprecated pass in the actor system instead of the materializer, since 3.0.0
+   * @deprecated pass in the actor system instead of the materializer, since Alpakka 3.0.0
    */
-  @deprecated("pass in the actor system instead of the materializer", "3.0.0")
+  @deprecated("pass in the actor system instead of the materializer", "Alpakka 3.0.0")
   def getBucket(bucketName: String,
       materializer: Materializer,
       attributes: Attributes): CompletionStage[Optional[Bucket]] =
@@ -92,9 +92,9 @@ object GCStorage {
    * @param bucketName the name of the bucket
    * @param location the region to put the bucket in
    * @return a `CompletionStage` of `Bucket` with created bucket
-   * @deprecated pass in the actor system instead of the materializer, since 3.0.0
+   * @deprecated pass in the actor system instead of the materializer, since Alpakka 3.0.0
    */
-  @deprecated("pass in the actor system instead of the materializer", "3.0.0")
+  @deprecated("pass in the actor system instead of the materializer", "Alpakka 3.0.0")
   def createBucket(bucketName: String,
       location: String,
       materializer: Materializer,
@@ -135,9 +135,9 @@ object GCStorage {
    *
    * @param bucketName the name of the bucket
    * @return a `CompletionStage` of `Done` on successful deletion
-   * @deprecated pass in the actor system instead of the materializer, since 3.0.0
+   * @deprecated pass in the actor system instead of the materializer, since Alpakka 3.0.0
    */
-  @deprecated("pass in the actor system instead of the materializer", "3.0.0")
+  @deprecated("pass in the actor system instead of the materializer", "Alpakka 3.0.0")
   def deleteBucket(bucketName: String, materializer: Materializer, attributes: Attributes): CompletionStage[Done] =
     GCStorageStream.deleteBucket(bucketName)(materializer, attributes).asJava
 

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/Credentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/Credentials.scala
@@ -81,7 +81,7 @@ object Credentials {
   private def parseNone(c: Config) = NoCredentials(c.getConfig("none"))
 
   private var _cache: Map[Any, Credentials] = ListMap.empty
-  @deprecated("Intended only to help with migration", "3.0.0")
+  @deprecated("Intended only to help with migration", "Alpakka 3.0.0")
   private[connectors] def cache(key: Any)(default: => Credentials) =
     _cache.getOrElse(key, {
         val credentials = default

--- a/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/FcmNotificationModels.scala
+++ b/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/FcmNotificationModels.scala
@@ -26,7 +26,8 @@ object FcmNotificationModels {
   case class BasicNotification(title: String, body: String)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidNotification */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidNotification", "Alpakka 3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidNotification",
+    "Alpakka 3.0.2")
   @Deprecated
   case class AndroidNotification(
       title: String,
@@ -53,7 +54,8 @@ object FcmNotificationModels {
       notification: AndroidNotification)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidMessagePriority */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidMessagePriority", "Alpakka 3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidMessagePriority",
+    "Alpakka 3.0.2")
   @Deprecated
   sealed trait AndroidMessagePriority
 
@@ -83,7 +85,8 @@ object FcmNotificationModels {
   case class ApnsConfig(headers: Map[String, String], rawPayload: String)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.NotificationTarget */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.NotificationTarget", "Alpakka 3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.NotificationTarget",
+    "Alpakka 3.0.2")
   @Deprecated
   sealed trait NotificationTarget
 

--- a/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/FcmNotificationModels.scala
+++ b/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/FcmNotificationModels.scala
@@ -16,17 +16,17 @@ package org.apache.pekko.stream.connectors.google.firebase.fcm
 import org.apache.pekko.stream.connectors.google.firebase.fcm.FcmNotificationModels._
 
 /** Use class from package org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models */
-@deprecated("Use class from package org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models", "3.0.2")
+@deprecated("Use class from package org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models", "Alpakka 3.0.2")
 @Deprecated
 object FcmNotificationModels {
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.BasicNotification */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.BasicNotification", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.BasicNotification", "Alpakka 3.0.2")
   @Deprecated
   case class BasicNotification(title: String, body: String)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidNotification */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidNotification", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidNotification", "Alpakka 3.0.2")
   @Deprecated
   case class AndroidNotification(
       title: String,
@@ -42,7 +42,7 @@ object FcmNotificationModels {
       title_loc_args: Seq[String])
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidConfig */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidConfig", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidConfig", "Alpakka 3.0.2")
   @Deprecated
   case class AndroidConfig(
       collapse_key: String,
@@ -53,57 +53,57 @@ object FcmNotificationModels {
       notification: AndroidNotification)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidMessagePriority */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidMessagePriority", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.AndroidMessagePriority", "Alpakka 3.0.2")
   @Deprecated
   sealed trait AndroidMessagePriority
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Normal */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Normal", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Normal", "Alpakka 3.0.2")
   @Deprecated
   case object Normal extends AndroidMessagePriority
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.High */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.High", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.High", "Alpakka 3.0.2")
   @Deprecated
   case object High extends AndroidMessagePriority
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.WebPushConfig */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.WebPushConfig", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.WebPushConfig", "Alpakka 3.0.2")
   @Deprecated
   case class WebPushNotification(title: String, body: String, icon: String)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.WebPushConfig */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.WebPushConfig", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.WebPushConfig", "Alpakka 3.0.2")
   @Deprecated
   case class WebPushConfig(headers: Map[String, String], data: Map[String, String], notification: WebPushNotification)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.ApnsConfig */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.ApnsConfig", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.ApnsConfig", "Alpakka 3.0.2")
   @Deprecated
   case class ApnsConfig(headers: Map[String, String], rawPayload: String)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.NotificationTarget */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.NotificationTarget", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.NotificationTarget", "Alpakka 3.0.2")
   @Deprecated
   sealed trait NotificationTarget
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Token */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Token", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Token", "Alpakka 3.0.2")
   @Deprecated
   case class Token(token: String) extends NotificationTarget
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Topic */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Topic", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Topic", "Alpakka 3.0.2")
   @Deprecated
   case class Topic(topic: String) extends NotificationTarget
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Condition */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Condition", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Condition", "Alpakka 3.0.2")
   @Deprecated
   case class Condition(conditionText: String) extends NotificationTarget
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Condition */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Condition", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.Condition", "Alpakka 3.0.2")
   @Deprecated
   object Condition {
     sealed trait ConditionBuilder {
@@ -131,7 +131,7 @@ object FcmNotificationModels {
 }
 
 /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmNotification */
-@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmNotification", "3.0.2")
+@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmNotification", "Alpakka 3.0.2")
 @Deprecated
 case class FcmNotification(
     data: Option[Map[String, String]] = None,
@@ -160,7 +160,7 @@ case class FcmNotification(
 }
 
 /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmNotification */
-@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmNotification", "3.0.2")
+@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmNotification", "Alpakka 3.0.2")
 @Deprecated
 object FcmNotification {
   val empty: FcmNotification = FcmNotification()
@@ -173,7 +173,7 @@ object FcmNotification {
 }
 
 /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmResponse */
-@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmResponse", "3.0.2")
+@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmResponse", "Alpakka 3.0.2")
 @Deprecated
 sealed trait FcmResponse {
   def isFailure: Boolean
@@ -181,7 +181,7 @@ sealed trait FcmResponse {
 }
 
 /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmSuccessResponse */
-@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmSuccessResponse", "3.0.2")
+@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmSuccessResponse", "Alpakka 3.0.2")
 @Deprecated
 final case class FcmSuccessResponse(name: String) extends FcmResponse {
   val isFailure = false
@@ -190,7 +190,7 @@ final case class FcmSuccessResponse(name: String) extends FcmResponse {
 }
 
 /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmErrorResponse */
-@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmErrorResponse", "3.0.2")
+@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.models.FcmErrorResponse", "Alpakka 3.0.2")
 @Deprecated
 final case class FcmErrorResponse(rawError: String) extends FcmResponse {
   val isFailure = true

--- a/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/FcmSettings.scala
+++ b/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/FcmSettings.scala
@@ -27,40 +27,40 @@ final class FcmSettings private (
     /** Use [[pekko.stream.connectors.google.GoogleSettings]] */
     @deprecated(
       "Use org.apache.pekko.stream.connectors.google.GoogleSettings",
-      "3.0.0") @Deprecated val clientEmail: String,
+      "Alpakka 3.0.0") @Deprecated val clientEmail: String,
     /** Use [[pekko.stream.connectors.google.GoogleSettings]] */
     @deprecated(
       "Use org.apache.pekko.stream.connectors.google.GoogleSettings",
-      "3.0.0") @Deprecated val privateKey: String,
+      "Alpakka 3.0.0") @Deprecated val privateKey: String,
     /** Use [[pekko.stream.connectors.google.GoogleSettings]] */
     @deprecated(
       "Use org.apache.pekko.stream.connectors.google.GoogleSettings",
-      "3.0.0") @Deprecated val projectId: String,
+      "Alpakka 3.0.0") @Deprecated val projectId: String,
     val isTest: Boolean,
     val maxConcurrentConnections: Int,
     /** Use [[pekko.stream.connectors.google.GoogleSettings]] */
     @deprecated(
       "Use org.apache.pekko.stream.connectors.google.GoogleSettings",
-      "3.0.0") @Deprecated val forwardProxy: Option[ForwardProxy] = Option.empty) {
+      "Alpakka 3.0.0") @Deprecated val forwardProxy: Option[ForwardProxy] = Option.empty) {
 
   /**
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
   @Deprecated
   def withClientEmail(value: String): FcmSettings = copy(clientEmail = value)
 
   /**
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
   @Deprecated
   def withPrivateKey(value: String): FcmSettings = copy(privateKey = value)
 
   /**
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
   @Deprecated
   def withProjectId(value: String): FcmSettings = copy(projectId = value)
 
@@ -71,7 +71,7 @@ final class FcmSettings private (
   /**
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
   @Deprecated
   def withForwardProxy(value: ForwardProxy): FcmSettings = copy(forwardProxy = Option(value))
 
@@ -97,7 +97,7 @@ final class FcmSettings private (
 /**
  * @deprecated Use [[pekko.stream.connectors.google.ForwardProxy]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "Alpakka 3.0.0")
 @Deprecated
 object ForwardProxyTrustPem {
 
@@ -114,7 +114,7 @@ object ForwardProxyTrustPem {
 /**
  * @deprecated Use [[pekko.stream.connectors.google.ForwardProxy]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "Alpakka 3.0.0")
 @Deprecated
 final class ForwardProxyTrustPem private (val pemPath: String) {
 
@@ -139,7 +139,7 @@ final class ForwardProxyTrustPem private (val pemPath: String) {
 /**
  * @deprecated Use [[pekko.stream.connectors.google.ForwardProxy]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "Alpakka 3.0.0")
 @Deprecated
 object ForwardProxyCredentials {
 
@@ -156,7 +156,7 @@ object ForwardProxyCredentials {
 /**
  * @deprecated Use [[pekko.stream.connectors.google.ForwardProxy]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "Alpakka 3.0.0")
 @Deprecated
 final class ForwardProxyCredentials private (val username: String, val password: String) {
 
@@ -193,7 +193,7 @@ final class ForwardProxyCredentials private (val username: String, val password:
 /**
  * @deprecated Use [[pekko.stream.connectors.google.ForwardProxy]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "Alpakka 3.0.0")
 @Deprecated
 object ForwardProxy {
 
@@ -228,7 +228,7 @@ object ForwardProxy {
 /**
  * @deprecated Use [[pekko.stream.connectors.google.ForwardProxy]]
  */
-@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "3.0.0")
+@deprecated("Use org.apache.pekko.stream.connectors.google.ForwardProxy", "Alpakka 3.0.0")
 @Deprecated
 final class ForwardProxy private (val host: String,
     val port: Int,
@@ -298,7 +298,7 @@ object FcmSettings {
    * Scala API
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
   @Deprecated
   def apply(
       clientEmail: String,
@@ -313,7 +313,7 @@ object FcmSettings {
   /**
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
   @Deprecated
   def apply(
       clientEmail: String,
@@ -331,7 +331,7 @@ object FcmSettings {
    * Java API
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
   @Deprecated
   def create(clientEmail: String, privateKey: String, projectId: String): FcmSettings = {
     apply(clientEmail, privateKey, projectId)
@@ -340,7 +340,7 @@ object FcmSettings {
   /**
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]]
    */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "3.0.0")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.GoogleSettings", "Alpakka 3.0.0")
   @Deprecated
   def create(clientEmail: String, privateKey: String, projectId: String, forwardProxy: ForwardProxy): FcmSettings = {
     apply(clientEmail, privateKey, projectId, forwardProxy)

--- a/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/impl/FcmFlows.scala
+++ b/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/impl/FcmFlows.scala
@@ -32,7 +32,7 @@ import scala.concurrent.Future
 private[fcm] object FcmFlows {
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmFlows */
-  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmFlows", "3.0.2")
+  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmFlows", "Alpakka 3.0.2")
   @Deprecated
   private[fcm] def fcmWithData[T](conf: FcmSettings): Flow[(FcmNotification, T), (FcmResponse, T), NotUsed] =
     Flow
@@ -49,7 +49,7 @@ private[fcm] object FcmFlows {
       .mapMaterializedValue(_ => NotUsed)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmFlows */
-  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmFlows", "3.0.2")
+  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmFlows", "Alpakka 3.0.2")
   @Deprecated
   private[fcm] def fcm(conf: FcmSettings): Flow[FcmNotification, FcmResponse, NotUsed] =
     Flow
@@ -62,7 +62,7 @@ private[fcm] object FcmFlows {
       }
       .mapMaterializedValue(_ => NotUsed)
 
-  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmFlows", "3.0.2")
+  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmFlows", "Alpakka 3.0.2")
   @Deprecated
   private def resolveSettings(conf: FcmSettings)(mat: Materializer, attr: Attributes): GoogleSettings = {
     val settings = GoogleAttributes.resolveSettings(mat, attr)

--- a/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/impl/FcmJsonSupport.scala
+++ b/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/impl/FcmJsonSupport.scala
@@ -25,7 +25,7 @@ import spray.json._
  * INTERNAL API
  */
 @InternalApi
-@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmSend", "3.0.2")
+@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmSend", "Alpakka 3.0.2")
 @Deprecated
 private[fcm] case class FcmSend(validate_only: Boolean, message: FcmNotification)
 
@@ -33,7 +33,7 @@ private[fcm] case class FcmSend(validate_only: Boolean, message: FcmNotification
  * INTERNAL API
  */
 @InternalApi
-@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmJsonSupport", "3.0.2")
+@deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmJsonSupport", "Alpakka 3.0.2")
 @Deprecated
 private[fcm] object FcmJsonSupport extends DefaultJsonProtocol with SprayJsonSupport {
 

--- a/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/impl/FcmSender.scala
+++ b/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/impl/FcmSender.scala
@@ -37,7 +37,7 @@ private[fcm] class FcmSender {
   import FcmJsonSupport._
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmSender */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmSender", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmSender", "Alpakka 3.0.2")
   @Deprecated
   def send(http: HttpExt, fcmSend: FcmSend)(
       implicit mat: Materializer,
@@ -64,7 +64,7 @@ private[fcm] class FcmSender {
   }.withDefaultRetry
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmErrorException */
-  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmErrorException", "3.0.2")
+  @deprecated("Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.impl.FcmErrorException", "Alpakka 3.0.2")
   @Deprecated
   private case class FcmErrorException(error: FcmErrorResponse) extends Exception
 }

--- a/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/javadsl/GoogleFcm.scala
+++ b/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/javadsl/GoogleFcm.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletionStage
 object GoogleFcm {
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.javadsl.GoogleFcm" */
-  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.javadsl.GoogleFcm", "3.0.2")
+  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.javadsl.GoogleFcm", "Alpakka 3.0.2")
   @Deprecated
   def sendWithPassThrough[T](conf: FcmSettings): javadsl.Flow[Pair[FcmNotification, T], Pair[FcmResponse, T], NotUsed] =
     scaladsl
@@ -36,13 +36,13 @@ object GoogleFcm {
       .asJava
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.javadsl.GoogleFcm" */
-  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.javadsl.GoogleFcm", "3.0.2")
+  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.javadsl.GoogleFcm", "Alpakka 3.0.2")
   @Deprecated
   def send(conf: FcmSettings): javadsl.Flow[FcmNotification, FcmResponse, NotUsed] =
     FcmFlows.fcm(conf).asJava
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.javadsl.GoogleFcm" */
-  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.javadsl.GoogleFcm", "3.0.2")
+  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.javadsl.GoogleFcm", "Alpakka 3.0.2")
   @Deprecated
   def fireAndForget(conf: FcmSettings): javadsl.Sink[FcmNotification, CompletionStage[Done]] =
     send(conf)

--- a/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/scaladsl/GoogleFcm.scala
+++ b/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/scaladsl/GoogleFcm.scala
@@ -24,19 +24,19 @@ import scala.concurrent.Future
 object GoogleFcm {
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.scaladsl.GoogleFcm */
-  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.scaladsl.GoogleFcm", "3.0.2")
+  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.scaladsl.GoogleFcm", "Alpakka 3.0.2")
   @Deprecated
   def sendWithPassThrough[T](conf: FcmSettings): Flow[(FcmNotification, T), (FcmResponse, T), NotUsed] =
     FcmFlows.fcmWithData[T](conf)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.scaladsl.GoogleFcm */
-  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.scaladsl.GoogleFcm", "3.0.2")
+  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.scaladsl.GoogleFcm", "Alpakka 3.0.2")
   @Deprecated
   def send(conf: FcmSettings): Flow[FcmNotification, FcmResponse, NotUsed] =
     FcmFlows.fcm(conf)
 
   /** Use org.apache.pekko.stream.connectors.google.firebase.fcm.v1.scaladsl.GoogleFcm */
-  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.scaladsl.GoogleFcm", "3.0.2")
+  @deprecated("org.apache.pekko.stream.connectors.google.firebase.fcm.v1.scaladsl.GoogleFcm", "Alpakka 3.0.2")
   @Deprecated
   def fireAndForget(conf: FcmSettings): Sink[FcmNotification, Future[Done]] =
     FcmFlows.fcm(conf).toMat(Sink.ignore)(Keep.right)

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/JmsExceptions.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/JmsExceptions.scala
@@ -30,7 +30,7 @@ case class UnsupportedMessagePropertyType(propertyName: String, propertyValue: A
       "Only primitive types and String are supported as property values.")
     with NonRetriableJmsException
 
-@deprecated("Not used anywhere", "3.0.4")
+@deprecated("Not used anywhere", "Alpakka 3.0.4")
 case class NullMessageProperty(propertyName: String, message: JmsEnvelope[_])
     extends Exception(
       s"null value was given for Jms property '$propertyName'.")
@@ -42,7 +42,7 @@ case class UnsupportedMapMessageEntryType(entryName: String, entryValue: Any, me
       "Only primitive types, String, and Byte array are supported as entry values.")
     with NonRetriableJmsException
 
-@deprecated("Not used anywhere", "3.0.4")
+@deprecated("Not used anywhere", "Alpakka 3.0.4")
 case class NullMapMessageEntry(entryName: String, message: JmsMapMessagePassThrough[_])
     extends Exception(
       s"null value was given for Jms MapMessage entry '$entryName'.")

--- a/sse/src/main/scala/org/apache/pekko/stream/connectors/sse/javadsl/EventSource.scala
+++ b/sse/src/main/scala/org/apache/pekko/stream/connectors/sse/javadsl/EventSource.scala
@@ -103,9 +103,9 @@ object EventSource {
    * @param lastEventId initial value for Last-Evend-ID header, optional
    * @param mat `Materializer`
    * @return continuous source of server-sent events
-   * @deprecated pass in the actor system instead of the materializer, since 3.0.0
+   * @deprecated pass in the actor system instead of the materializer, since Alpakka 3.0.0
    */
-  @deprecated("pass in the actor system instead of the materializer", "3.0.0")
+  @deprecated("pass in the actor system instead of the materializer", "Alpakka 3.0.0")
   def create(uri: Uri,
       send: JFunction[HttpRequest, CompletionStage[HttpResponse]],
       lastEventId: Optional[String],


### PR DESCRIPTION
Pekko Connectors versions will start at 1.0.0 so it will be confusing if we have deprecations that are since '3.0.0'. We need to prefix such version numbers to make it clear they relate to Alpakka releases.