### PR TITLE
Scala3 couchbase support

### DIFF
--- a/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/model.scala
+++ b/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/model.scala
@@ -270,7 +270,7 @@ sealed trait CouchbaseWriteResult[T <: Document[_]] {
 /**
  * Emitted for a successful Couchbase write operation.
  */
-final case class CouchbaseWriteSuccess[T <: Document[_]] private (override val doc: T) extends CouchbaseWriteResult[T] {
+final case class CouchbaseWriteSuccess[T <: Document[_]] private[couchbase] (override val doc: T) extends CouchbaseWriteResult[T] {
   val isSuccess: Boolean = true
   val isFailure: Boolean = false
 }
@@ -278,7 +278,7 @@ final case class CouchbaseWriteSuccess[T <: Document[_]] private (override val d
 /**
  * Emitted for a failed Couchbase write operation.
  */
-final case class CouchbaseWriteFailure[T <: Document[_]] private (override val doc: T, failure: Throwable)
+final case class CouchbaseWriteFailure[T <: Document[_]] private[couchbase] (override val doc: T, failure: Throwable)
     extends CouchbaseWriteResult[T] {
   val isSuccess: Boolean = false
   val isFailure: Boolean = true
@@ -296,7 +296,7 @@ sealed trait CouchbaseDeleteResult {
 /**
  * Emitted for a successful Couchbase write operation.
  */
-final case class CouchbaseDeleteSuccess private (override val id: String) extends CouchbaseDeleteResult {
+final case class CouchbaseDeleteSuccess private[couchbase] (override val id: String) extends CouchbaseDeleteResult {
   val isSuccess: Boolean = true
   val isFailure: Boolean = false
 }
@@ -304,7 +304,7 @@ final case class CouchbaseDeleteSuccess private (override val id: String) extend
 /**
  * Emitted for a failed Couchbase write operation.
  */
-final case class CouchbaseDeleteFailure private (override val id: String, failure: Throwable)
+final case class CouchbaseDeleteFailure private[couchbase] (override val id: String, failure: Throwable)
     extends CouchbaseDeleteResult {
   val isSuccess: Boolean = false
   val isFailure: Boolean = true

--- a/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/model.scala
+++ b/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/model.scala
@@ -270,7 +270,8 @@ sealed trait CouchbaseWriteResult[T <: Document[_]] {
 /**
  * Emitted for a successful Couchbase write operation.
  */
-final case class CouchbaseWriteSuccess[T <: Document[_]] private[couchbase] (override val doc: T) extends CouchbaseWriteResult[T] {
+final case class CouchbaseWriteSuccess[T <: Document[_]] private[couchbase] (
+    override val doc: T) extends CouchbaseWriteResult[T] {
   val isSuccess: Boolean = true
   val isFailure: Boolean = false
 }

--- a/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/scaladsl/CouchbaseFlow.scala
+++ b/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/scaladsl/CouchbaseFlow.scala
@@ -29,7 +29,7 @@ import pekko.stream.connectors.couchbase.{
 import pekko.stream.scaladsl.Flow
 import com.couchbase.client.java.document.{ Document, JsonDocument }
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * Scala API: Factory methods for Couchbase flows.
@@ -100,8 +100,8 @@ object CouchbaseFlow {
    */
   def upsertDocWithResult[T <: Document[_]](sessionSettings: CouchbaseSessionSettings,
       writeSettings: CouchbaseWriteSettings,
-      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] =
-    Flow
+      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] = {
+    val flow: Flow[T, CouchbaseWriteResult[T], Future[NotUsed]] = Flow
       .fromMaterializer { (materializer, _) =>
         val session = CouchbaseSessionRegistry(materializer.system).sessionFor(sessionSettings, bucketName)
         Flow[T]
@@ -115,7 +115,8 @@ object CouchbaseFlow {
               }
           })
       }
-      .mapMaterializedValue(_ => NotUsed)
+    flow.mapMaterializedValue(_ => NotUsed)
+  }
 
   /**
    * Create a flow to replace a Couchbase [[com.couchbase.client.java.document.JsonDocument JsonDocument]].
@@ -153,8 +154,8 @@ object CouchbaseFlow {
    */
   def replaceDocWithResult[T <: Document[_]](sessionSettings: CouchbaseSessionSettings,
       writeSettings: CouchbaseWriteSettings,
-      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] =
-    Flow
+      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] = {
+    val flow: Flow[T, CouchbaseWriteResult[T], Future[NotUsed]] = Flow
       .fromMaterializer { (materializer, _) =>
         val session = CouchbaseSessionRegistry(materializer.system).sessionFor(sessionSettings, bucketName)
         Flow[T]
@@ -168,7 +169,8 @@ object CouchbaseFlow {
               }
           })
       }
-      .mapMaterializedValue(_ => NotUsed)
+    flow.mapMaterializedValue(_ => NotUsed)
+  }
 
   /**
    * Create a flow to delete documents from Couchbase by `id`. Emits the same `id`.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,10 +129,9 @@ object Dependencies {
       "com.couchbase.client" % "java-client" % CouchbaseVersion, // ApacheV2
       "io.reactivex" % "rxjava-reactive-streams" % "1.2.1", // ApacheV2
       "org.apache.pekko" %% "pekko-discovery" % PekkoVersion % Provided, // Apache V2
+      "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion % Test, // Apache V2
       "com.fasterxml.jackson.core" % "jackson-databind" % JacksonDatabindVersion % Test, // Apache V2
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonDatabindVersion % Test, // Apache V2
-      "com.typesafe.play" %% "play-json" % "2.10.0-RC8" % Test, // Apache V2
-      "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion % Test // Apache V2
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonDatabindVersion % Test // Apache V2
     ))
 
   val `Doc-examples` = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,6 +129,8 @@ object Dependencies {
       "com.couchbase.client" % "java-client" % CouchbaseVersion, // ApacheV2
       "io.reactivex" % "rxjava-reactive-streams" % "1.2.1", // ApacheV2
       "org.apache.pekko" %% "pekko-discovery" % PekkoVersion % Provided, // Apache V2
+      "com.fasterxml.jackson.core" % "jackson-databind" % JacksonDatabindVersion % Test, // Apache V2
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonDatabindVersion % Test, // Apache V2
       "com.typesafe.play" %% "play-json" % "2.10.0-RC8" % Test, // Apache V2
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion % Test // Apache V2
     ))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -125,12 +125,11 @@ object Dependencies {
       "org.apache.pekko" %% "pekko-discovery" % PekkoVersion % Provided))
 
   val Couchbase = Seq(
-    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "com.couchbase.client" % "java-client" % CouchbaseVersion, // ApacheV2
       "io.reactivex" % "rxjava-reactive-streams" % "1.2.1", // ApacheV2
       "org.apache.pekko" %% "pekko-discovery" % PekkoVersion % Provided, // Apache V2
-      "com.typesafe.play" %% "play-json" % "2.9.2" % Test, // Apache V2
+      "com.typesafe.play" %% "play-json" % "2.10.0-RC8" % Test, // Apache V2
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion % Test // Apache V2
     ))
 


### PR DESCRIPTION
* I've worked through a couple of compile issues
* play-json (a test dependency) doesn't have a full release that supports Scala 3 and furthermore, the 2.10.0 RCs only support Java 11.
* it was easy to test with jackson instead
* this PR is targeted at the 'scala3' branch