### PR TITLE
avro4s 4.1.1 (test dependency)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -166,7 +166,7 @@ object Dependencies {
       "org.apache.parquet" % "parquet-avro" % "1.10.1", // Apache2
       ("org.apache.hadoop" % "hadoop-client" % "3.2.1" % Test).exclude("log4j", "log4j"), // Apache2
       ("org.apache.hadoop" % "hadoop-common" % "3.2.1" % Test).exclude("log4j", "log4j"), // Apache2
-      "com.sksamuel.avro4s" %% "avro4s-core" % "3.0.9" % Test,
+      "com.sksamuel.avro4s" %% "avro4s-core" % "4.1.1" % Test,
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion % Test,
       "org.specs2" %% "specs2-core" % "4.8.3" % Test, // MIT like: https://github.com/etorreborre/specs2/blob/master/LICENSE.txt
       "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test // MIT like: http://www.slf4j.org/license.html


### PR DESCRIPTION
a test only dependency - v5 is scala 3 only but I want to get up to v4 first - and then add logic to use different versions depending on scala version