### PR TITLE
Use pekko-streams-circe for IronMQ

### DIFF
--- a/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/impl/IronMqClient.scala
+++ b/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/impl/IronMqClient.scala
@@ -28,9 +28,9 @@ import pekko.stream.connectors.ironmq._
 import pekko.stream.scaladsl.{ Flow, Sink, Source }
 import pekko.{ Done, NotUsed }
 import com.typesafe.config.Config
-import com.github.pjfanning.pekkohttpcirce.ErrorAccumulatingCirceSupport._
 import io.circe.Json
 import io.circe.syntax._
+import org.mdedetrich.pekko.http.support.CirceHttpSupport._
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.concurrent.{ ExecutionContext, Future }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -299,7 +299,8 @@ object Dependencies {
   val IronMq = Seq(
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
-      "com.github.pjfanning" %% "pekko-http-circe" % "1.40.0-RC3_23-bb29e2a9-SNAPSHOT" // ApacheV2
+      "org.mdedetrich" %% "pekko-stream-circe" % "0.0.0+94-dbf3173f-SNAPSHOT", // ApacheV2
+      "org.mdedetrich" %% "pekko-http-circe" % "0.0.0+94-dbf3173f-SNAPSHOT" // ApacheV2
     ))
 
   val Jms = Seq(


### PR DESCRIPTION
As discussed on mailing list (see https://lists.apache.org/thread/qx31xljn6bf7rwcd3kbb9btcdvoxmmwy), replaces the fork of https://github.com/hseeberger/akka-http-json with [pekko-streams-circe](https://github.com/mdedetrich/pekko-streams-circe)