### PR TITLE
one of HmsSettings apply functions recurses indefinitely (huawei-push-kit)

### DIFF
--- a/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/HmsSettings.scala
+++ b/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/HmsSettings.scala
@@ -123,7 +123,8 @@ object HmsSettings {
   def apply(
       appId: String,
       appSecret: String,
-      forwardProxy: Option[ForwardProxy]): HmsSettings = apply(appId, appSecret, forwardProxy)
+      forwardProxy: Option[ForwardProxy]): HmsSettings =
+    apply(appId, appSecret, IsTest, MaxConcurrentConnections, forwardProxy)
 
   /**
    * Java API.


### PR DESCRIPTION
* Function accidentally calls itself instead of delegating to another apply function.
* the equivalent Java API `create` method uses the broken `apply` function
* found by Scala 3 compiler

