### PR TITLE
Scala3 support for jms connector

### DIFF
--- a/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/scaladsl/CouchbaseFlow.scala
+++ b/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/scaladsl/CouchbaseFlow.scala
@@ -29,7 +29,7 @@ import pekko.stream.connectors.couchbase.{
 import pekko.stream.scaladsl.Flow
 import com.couchbase.client.java.document.{ Document, JsonDocument }
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * Scala API: Factory methods for Couchbase flows.
@@ -100,8 +100,8 @@ object CouchbaseFlow {
    */
   def upsertDocWithResult[T <: Document[_]](sessionSettings: CouchbaseSessionSettings,
       writeSettings: CouchbaseWriteSettings,
-      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] =
-    Flow
+      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] = {
+    val flow: Flow[T, CouchbaseWriteResult[T], Future[NotUsed]] = Flow
       .fromMaterializer { (materializer, _) =>
         val session = CouchbaseSessionRegistry(materializer.system).sessionFor(sessionSettings, bucketName)
         Flow[T]
@@ -115,7 +115,8 @@ object CouchbaseFlow {
               }
           })
       }
-      .mapMaterializedValue(_ => NotUsed)
+    flow.mapMaterializedValue(_ => NotUsed)
+  }
 
   /**
    * Create a flow to replace a Couchbase [[com.couchbase.client.java.document.JsonDocument JsonDocument]].
@@ -153,8 +154,8 @@ object CouchbaseFlow {
    */
   def replaceDocWithResult[T <: Document[_]](sessionSettings: CouchbaseSessionSettings,
       writeSettings: CouchbaseWriteSettings,
-      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] =
-    Flow
+      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] = {
+    val flow: Flow[T, CouchbaseWriteResult[T], Future[NotUsed]] = Flow
       .fromMaterializer { (materializer, _) =>
         val session = CouchbaseSessionRegistry(materializer.system).sessionFor(sessionSettings, bucketName)
         Flow[T]
@@ -168,7 +169,8 @@ object CouchbaseFlow {
               }
           })
       }
-      .mapMaterializedValue(_ => NotUsed)
+    flow.mapMaterializedValue(_ => NotUsed)
+  }
 
   /**
    * Create a flow to delete documents from Couchbase by `id`. Emits the same `id`.

--- a/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/scaladsl/CouchbaseFlow.scala
+++ b/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/scaladsl/CouchbaseFlow.scala
@@ -29,7 +29,7 @@ import pekko.stream.connectors.couchbase.{
 import pekko.stream.scaladsl.Flow
 import com.couchbase.client.java.document.{ Document, JsonDocument }
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.ExecutionContext
 
 /**
  * Scala API: Factory methods for Couchbase flows.
@@ -100,8 +100,8 @@ object CouchbaseFlow {
    */
   def upsertDocWithResult[T <: Document[_]](sessionSettings: CouchbaseSessionSettings,
       writeSettings: CouchbaseWriteSettings,
-      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] = {
-    val flow: Flow[T, CouchbaseWriteResult[T], Future[NotUsed]] = Flow
+      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] =
+    Flow
       .fromMaterializer { (materializer, _) =>
         val session = CouchbaseSessionRegistry(materializer.system).sessionFor(sessionSettings, bucketName)
         Flow[T]
@@ -115,8 +115,7 @@ object CouchbaseFlow {
               }
           })
       }
-    flow.mapMaterializedValue(_ => NotUsed)
-  }
+      .mapMaterializedValue(_ => NotUsed)
 
   /**
    * Create a flow to replace a Couchbase [[com.couchbase.client.java.document.JsonDocument JsonDocument]].
@@ -154,8 +153,8 @@ object CouchbaseFlow {
    */
   def replaceDocWithResult[T <: Document[_]](sessionSettings: CouchbaseSessionSettings,
       writeSettings: CouchbaseWriteSettings,
-      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] = {
-    val flow: Flow[T, CouchbaseWriteResult[T], Future[NotUsed]] = Flow
+      bucketName: String): Flow[T, CouchbaseWriteResult[T], NotUsed] =
+    Flow
       .fromMaterializer { (materializer, _) =>
         val session = CouchbaseSessionRegistry(materializer.system).sessionFor(sessionSettings, bucketName)
         Flow[T]
@@ -169,8 +168,7 @@ object CouchbaseFlow {
               }
           })
       }
-    flow.mapMaterializedValue(_ => NotUsed)
-  }
+      .mapMaterializedValue(_ => NotUsed)
 
   /**
    * Create a flow to delete documents from Couchbase by `id`. Emits the same `id`.

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/impl/RestBulkApi.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/impl/RestBulkApi.scala
@@ -46,8 +46,8 @@ private[impl] abstract class RestBulkApi[T, C] {
 
   def messageToJson(message: WriteMessage[T, C], messageSource: String): String = message.operation match {
     case Index | Create => "\n" + messageSource
-    case Upsert         => "\n" + JsObject("doc" -> messageSource.parseJson, "doc_as_upsert" -> JsTrue).toString
-    case Update         => "\n" + JsObject("doc" -> messageSource.parseJson).toString
+    case Upsert         => "\n" + JsObject("doc" -> messageSource.parseJson, "doc_as_upsert" -> JsTrue).compactPrint
+    case Update         => "\n" + JsObject("doc" -> messageSource.parseJson).compactPrint
     case Delete         => ""
     case Nop            => ""
   }
@@ -69,7 +69,7 @@ private[impl] abstract class RestBulkApi[T, C] {
           // good message
           val command = message.operation.command
           val res = itemsIter.next().asJsObject.fields(command).asJsObject
-          val error: Option[String] = res.fields.get("error").map(_.toString())
+          val error: Option[String] = res.fields.get("error").map(_.compactPrint)
           ret += new WriteResult(message, error)
         } else {
           // error?

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchConnectorBehaviour.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchConnectorBehaviour.scala
@@ -200,7 +200,7 @@ trait ElasticsearchConnectorBehaviour {
           .via(
             ElasticsearchFlow.create(
               constructElasticsearchParams(indexName, "_doc", apiVersion),
-              baseWriteSettings.withRetryLogic(RetryAtFixedRate(5, 100.millis))))
+              baseWriteSettings.withRetryLogic(RetryAtFixedRate(5, 100.millis)))(RootJsObjectFormat))
           .runWith(Sink.seq)
 
         val start = System.currentTimeMillis()
@@ -286,7 +286,7 @@ trait ElasticsearchConnectorBehaviour {
           .via(
             ElasticsearchFlow.createWithContext(
               constructElasticsearchParams(indexName, "_doc", apiVersion),
-              baseWriteSettings.withRetryLogic(RetryAtFixedRate(5, 100.millis))))
+              baseWriteSettings.withRetryLogic(RetryAtFixedRate(5, 100.millis)))(RootJsObjectFormat))
           .runWith(Sink.seq)
 
         val start = System.currentTimeMillis()

--- a/elasticsearch/src/test/scala/docs/scaladsl/OpensearchConnectorBehaviour.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/OpensearchConnectorBehaviour.scala
@@ -200,7 +200,7 @@ trait OpensearchConnectorBehaviour {
           .via(
             ElasticsearchFlow.create(
               constructElasticsearchParams(indexName, "_doc", apiVersion),
-              baseWriteSettings.withRetryLogic(RetryAtFixedRate(5, 100.millis))))
+              baseWriteSettings.withRetryLogic(RetryAtFixedRate(5, 100.millis)))(RootJsObjectFormat))
           .runWith(Sink.seq)
 
         val start = System.currentTimeMillis()
@@ -286,7 +286,7 @@ trait OpensearchConnectorBehaviour {
           .via(
             ElasticsearchFlow.createWithContext(
               constructElasticsearchParams(indexName, "_doc", apiVersion),
-              baseWriteSettings.withRetryLogic(RetryAtFixedRate(5, 100.millis))))
+              baseWriteSettings.withRetryLogic(RetryAtFixedRate(5, 100.millis)))(RootJsObjectFormat))
           .runWith(Sink.seq)
 
         val start = System.currentTimeMillis()

--- a/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/impl/PubSubApi.scala
+++ b/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/impl/PubSubApi.scala
@@ -69,7 +69,7 @@ private[pubsub] trait PubSubApi {
   def PubSubGoogleApisPort: Int
   def isEmulated: Boolean
 
-  private implicit val instantFormat: RootJsonFormat[Instant] = new RootJsonFormat[Instant] {
+  private implicit val instantFormat = new RootJsonFormat[Instant] {
     override def read(jsValue: JsValue): Instant = jsValue match {
       case JsString(time) => Instant.parse(time)
       case _              => deserializationError("Instant required as a string of RFC3339 UTC Zulu format.")
@@ -77,7 +77,7 @@ private[pubsub] trait PubSubApi {
     override def write(instant: Instant): JsValue = JsString(instant.toString)
   }
 
-  private implicit val pubSubMessageFormat: RootJsonFormat[PubSubMessage] =
+  private implicit val pubSubMessageFormat =
     new RootJsonFormat[PubSubMessage] {
       override def read(json: JsValue): PubSubMessage = {
         val fields = json.asJsObject.fields
@@ -98,7 +98,7 @@ private[pubsub] trait PubSubApi {
           ++ m.attributes.map(attributes => "attributes" -> attributes.toJson): _*)
     }
 
-  private implicit val publishMessageFormat: RootJsonFormat[PublishMessage] = new RootJsonFormat[PublishMessage] {
+  private implicit val publishMessageFormat = new RootJsonFormat[PublishMessage] {
     def read(json: JsValue): PublishMessage = {
       val data = json.asJsObject.fields("data").convertTo[String]
       val attributes = json.asJsObject.fields("attributes").convertTo[immutable.Map[String, String]]
@@ -112,39 +112,37 @@ private[pubsub] trait PubSubApi {
         m.attributes.map(a => "attributes" -> a.toJson): _*)
   }
 
-  private implicit val pubSubRequestFormat: RootJsonFormat[PublishRequest] = new RootJsonFormat[PublishRequest] {
+  private implicit val pubSubRequestFormat = new RootJsonFormat[PublishRequest] {
     def read(json: JsValue): PublishRequest =
       PublishRequest(json.asJsObject.fields("messages").convertTo[immutable.Seq[PublishMessage]])
     def write(pr: PublishRequest): JsValue = JsObject("messages" -> pr.messages.toJson)
   }
-  private implicit val gcePubSubResponseFormat: RootJsonFormat[PublishResponse] = new RootJsonFormat[PublishResponse] {
+  private implicit val gcePubSubResponseFormat = new RootJsonFormat[PublishResponse] {
     def read(json: JsValue): PublishResponse =
       PublishResponse(json.asJsObject.fields("messageIds").convertTo[immutable.Seq[String]])
     def write(pr: PublishResponse): JsValue = JsObject("messageIds" -> pr.messageIds.toJson)
   }
 
-  private implicit val receivedMessageFormat: RootJsonFormat[ReceivedMessage] = new RootJsonFormat[ReceivedMessage] {
+  private implicit val receivedMessageFormat = new RootJsonFormat[ReceivedMessage] {
     def read(json: JsValue): ReceivedMessage =
       ReceivedMessage(json.asJsObject.fields("ackId").convertTo[String],
         json.asJsObject.fields("message").convertTo[PubSubMessage])
     def write(rm: ReceivedMessage): JsValue =
       JsObject("ackId" -> rm.ackId.toJson, "message" -> rm.message.toJson)
   }
-  private implicit val pubSubPullResponseFormat: RootJsonFormat[PullResponse] = new RootJsonFormat[PullResponse] {
+  private implicit val pubSubPullResponseFormat = new RootJsonFormat[PullResponse] {
     def read(json: JsValue): PullResponse =
       PullResponse(json.asJsObject.fields.get("receivedMessages").map(_.convertTo[immutable.Seq[ReceivedMessage]]))
     def write(pr: PullResponse): JsValue =
       pr.receivedMessages.map(rm => JsObject("receivedMessages" -> rm.toJson)).getOrElse(JsObject.empty)
   }
 
-  private implicit val acknowledgeRequestFormat: RootJsonFormat[AcknowledgeRequest] =
-    new RootJsonFormat[AcknowledgeRequest] {
-      def read(json: JsValue): AcknowledgeRequest =
-        AcknowledgeRequest(json.asJsObject.fields("ackIds").convertTo[immutable.Seq[String]]: _*)
-      def write(ar: AcknowledgeRequest): JsValue = JsObject("ackIds" -> ar.ackIds.toJson)
-    }
-  private implicit val pullRequestFormat: RootJsonFormat[PullRequest] =
-    DefaultJsonProtocol.jsonFormat2(PullRequest.apply)
+  private implicit val acknowledgeRequestFormat = new RootJsonFormat[AcknowledgeRequest] {
+    def read(json: JsValue): AcknowledgeRequest =
+      AcknowledgeRequest(json.asJsObject.fields("ackIds").convertTo[immutable.Seq[String]]: _*)
+    def write(ar: AcknowledgeRequest): JsValue = JsObject("ackIds" -> ar.ackIds.toJson)
+  }
+  private implicit val pullRequestFormat = DefaultJsonProtocol.jsonFormat2(PullRequest.apply)
 
   private def scheme: String = if (isEmulated) "http" else "https"
 
@@ -175,7 +173,7 @@ private[pubsub] trait PubSubApi {
       .mapMaterializedValue(_ => NotUsed)
 
   private implicit val pullResponseUnmarshaller: FromResponseUnmarshaller[PullResponse] =
-    Unmarshaller.withMaterializer { implicit ec => implicit mat => (response: HttpResponse) =>
+    Unmarshaller.withMaterializer { implicit ec => implicit mat => response: HttpResponse =>
       response.status match {
         case StatusCodes.Success(_) if response.entity.contentType == ContentTypes.`application/json` =>
           Unmarshal(response.entity).to[PullResponse]
@@ -213,7 +211,7 @@ private[pubsub] trait PubSubApi {
       .mapMaterializedValue(_ => NotUsed)
 
   private implicit val acknowledgeResponseUnmarshaller: FromResponseUnmarshaller[Done] =
-    Unmarshaller.withMaterializer { implicit ec => implicit mat => (response: HttpResponse) =>
+    Unmarshaller.withMaterializer { implicit ec => implicit mat => response: HttpResponse =>
       response.status match {
         case StatusCodes.Success(_) =>
           response.discardEntityBytes().future
@@ -263,7 +261,7 @@ private[pubsub] trait PubSubApi {
     publish(topic, parallelism, None)
 
   private implicit val publishResponseUnmarshaller: FromResponseUnmarshaller[PublishResponse] =
-    Unmarshaller.withMaterializer { implicit ec => implicit mat => (response: HttpResponse) =>
+    Unmarshaller.withMaterializer { implicit ec => implicit mat => response: HttpResponse =>
       response.status match {
         case StatusCodes.Success(_) if response.entity.contentType == ContentTypes.`application/json` =>
           Unmarshal(response.entity).to[PublishResponse]

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/Formats.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/Formats.scala
@@ -49,8 +49,7 @@ object Formats extends DefaultJsonProtocol {
       domain: String,
       projectTeam: ProjectTeam,
       etag: String)
-  private implicit val ObjectAccessControlsJsonFormat: RootJsonFormat[ObjectAccessControls] =
-    jsonFormat13(ObjectAccessControls.apply)
+  private implicit val ObjectAccessControlsJsonFormat = jsonFormat13(ObjectAccessControls)
 
   /**
    * Google API storage response object
@@ -80,8 +79,7 @@ object Formats extends DefaultJsonProtocol {
       timeStorageClassUpdated: String,
       updated: String)
 
-  private implicit val storageObjectReadOnlyJson: RootJsonFormat[StorageObjectReadOnlyJson] =
-    jsonFormat18(StorageObjectReadOnlyJson.apply)
+  private implicit val storageObjectReadOnlyJson = jsonFormat18(StorageObjectReadOnlyJson)
 
   // private sub class of StorageObjectJson used to workaround 22 field jsonFormat issue
   private final case class StorageObjectWriteableJson(
@@ -100,8 +98,7 @@ object Formats extends DefaultJsonProtocol {
       temporaryHold: Option[Boolean],
       acl: Option[List[ObjectAccessControls]])
 
-  private implicit val storageObjectWritableJson: RootJsonFormat[StorageObjectWriteableJson] =
-    jsonFormat14(StorageObjectWriteableJson.apply)
+  private implicit val storageObjectWritableJson = jsonFormat14(StorageObjectWriteableJson)
 
   private implicit object StorageObjectJsonFormat extends RootJsonFormat[StorageObjectJson] {
     override def read(value: JsValue): StorageObjectJson = {
@@ -178,8 +175,7 @@ object Formats extends DefaultJsonProtocol {
     }
   }
 
-  private implicit val bucketListResultJsonReads: RootJsonFormat[BucketListResultJson] =
-    jsonFormat4(BucketListResultJson.apply)
+  private implicit val bucketListResultJsonReads = jsonFormat4(BucketListResultJson.apply)
 
   implicit object RewriteResponseReads extends RootJsonReader[RewriteResponse] {
     override def read(json: JsValue): RewriteResponse = {

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/WithMaterializerGlobal.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/WithMaterializerGlobal.scala
@@ -29,7 +29,7 @@ trait WithMaterializerGlobal
     with ScalaFutures
     with IntegrationPatience
     with Matchers {
-  implicit val actorSystem: ActorSystem = ActorSystem("test")
+  implicit val actorSystem = ActorSystem("test")
   implicit val ec: ExecutionContext = actorSystem.dispatcher
 
   override protected def afterAll(): Unit = {

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/ResumableUpload.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/ResumableUpload.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream.connectors.google
 
 import org.apache.pekko
+import pekko.actor.ActorSystem
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model.HttpMethods.{ POST, PUT }
@@ -55,7 +56,7 @@ private[connectors] object ResumableUpload {
     Sink
       .fromMaterializer { (mat, attr) =>
         import mat.executionContext
-        implicit val materializer: Materializer = mat
+        implicit val materializer = mat
         implicit val settings: GoogleSettings = GoogleAttributes.resolveSettings(mat, attr)
         val uploadChunkSize = settings.requestSettings.uploadChunkSize
 
@@ -95,24 +96,25 @@ private[connectors] object ResumableUpload {
 
   private def initiateSession(request: HttpRequest)(implicit mat: Materializer,
       settings: GoogleSettings): Future[Uri] = {
+    implicit val system: ActorSystem = mat.system
     import implicits._
 
-    implicit val um: FromResponseUnmarshaller[Uri] =
-      Unmarshaller.withMaterializer { implicit ec => implicit mat => (response: HttpResponse) =>
-        response.discardEntityBytes().future.map { _ =>
-          response.header[Location].fold(throw InvalidResponseException(ErrorInfo("No Location header")))(_.uri)
-        }
-      }.withDefaultRetry
+    implicit val um = Unmarshaller.withMaterializer { implicit ec => implicit mat => response: HttpResponse =>
+      response.discardEntityBytes().future.map { _ =>
+        response.header[Location].fold(throw InvalidResponseException(ErrorInfo("No Location header")))(_.uri)
+      }
+    }.withDefaultRetry
 
-    GoogleHttp(mat.system).singleAuthenticatedRequest[Uri](request)
+    GoogleHttp().singleAuthenticatedRequest[Uri](request)
   }
 
   private final case class DoNotRetry(ex: Throwable) extends Throwable(ex) with NoStackTrace
 
   private def uploadChunk[T: FromResponseUnmarshaller](
       request: HttpRequest)(implicit mat: Materializer): Flow[Either[T, MaybeLast[Chunk]], Try[Option[T]], NotUsed] = {
+    implicit val system: ActorSystem = mat.system
 
-    val um = Unmarshaller.withMaterializer { implicit ec => implicit mat => (response: HttpResponse) =>
+    val um = Unmarshaller.withMaterializer { implicit ec => implicit mat => response: HttpResponse =>
       response.status match {
         case PermanentRedirect =>
           response.discardEntityBytes().future.map(_ => None)
@@ -125,8 +127,7 @@ private[connectors] object ResumableUpload {
       val uri = request.uri
       Flow[HttpRequest]
         .map((_, ()))
-        .via(GoogleHttp(mat.system).cachedHostConnectionPoolWithContext(uri.authority.host.address, uri.effectivePort)(
-          um))
+        .via(GoogleHttp().cachedHostConnectionPoolWithContext(uri.authority.host.address, uri.effectivePort)(um))
         .map(_._1.recoverWith { case DoNotRetry(ex) => Failure(ex) })
     }
 
@@ -146,30 +147,30 @@ private[connectors] object ResumableUpload {
       request: HttpRequest,
       chunk: Future[MaybeLast[Chunk]])(
       implicit mat: Materializer, settings: GoogleSettings): Future[Either[T, MaybeLast[Chunk]]] = {
+    implicit val system: ActorSystem = mat.system
     import implicits._
 
-    implicit val um: FromResponseUnmarshaller[Either[T, Long]] =
-      Unmarshaller.withMaterializer { implicit ec => implicit mat => (response: HttpResponse) =>
-        response.status match {
-          case OK | Created => Unmarshal(response).to[T].map(Left(_))
-          case PermanentRedirect =>
-            response.discardEntityBytes().future.map { _ =>
-              Right(
-                response
-                  .header[Range]
-                  .flatMap(_.ranges.headOption)
-                  .collect {
-                    case Slice(_, last) => last + 1
-                  }.getOrElse(0L))
-            }
-          case _ => throw InvalidResponseException(ErrorInfo(response.status.value, response.status.defaultMessage))
-        }
-      }.withDefaultRetry
+    implicit val um = Unmarshaller.withMaterializer { implicit ec => implicit mat => response: HttpResponse =>
+      response.status match {
+        case OK | Created => Unmarshal(response).to[T].map(Left(_))
+        case PermanentRedirect =>
+          response.discardEntityBytes().future.map { _ =>
+            Right(
+              response
+                .header[Range]
+                .flatMap(_.ranges.headOption)
+                .collect {
+                  case Slice(_, last) => last + 1
+                }.getOrElse(0L))
+          }
+        case _ => throw InvalidResponseException(ErrorInfo(response.status.value, response.status.defaultMessage))
+      }
+    }.withDefaultRetry
 
     import mat.executionContext
     chunk.flatMap {
       case maybeLast @ MaybeLast(Chunk(bytes, position)) =>
-        GoogleHttp(mat.system)
+        GoogleHttp()
           .singleAuthenticatedRequest[Either[T, Long]](request.addHeader(statusRequestHeader))
           .map {
             case Left(result) if maybeLast.isLast => Left(result)

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/GoogleOAuth2Spec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/GoogleOAuth2Spec.scala
@@ -46,7 +46,7 @@ class GoogleOAuth2Spec
 
   implicit val executionContext: ExecutionContext = system.dispatcher
   implicit val settings: GoogleSettings = GoogleSettings(system)
-  implicit val clock: Clock = Clock.systemUTC()
+  implicit val clock = Clock.systemUTC()
 
   lazy val privateKey = {
     val inputStream = getClass.getClassLoader.getResourceAsStream("private_pcks8.pem")

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/OAuth2CredentialsSpec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/OAuth2CredentialsSpec.scala
@@ -45,7 +45,7 @@ class OAuth2CredentialsSpec
   import system.dispatcher
 
   implicit val settings: RequestSettings = GoogleSettings().requestSettings
-  implicit val clock: Clock = Clock.systemUTC()
+  implicit val clock = Clock.systemUTC()
 
   final object AccessTokenProvider {
     @volatile var accessTokenPromise: Promise[AccessToken] = Promise.failed(new RuntimeException)

--- a/google-fcm/src/test/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/v1/impl/FcmSenderSpec.scala
+++ b/google-fcm/src/test/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/v1/impl/FcmSenderSpec.scala
@@ -57,7 +57,7 @@ class FcmSenderSpec
 
   implicit val executionContext: ExecutionContext = system.dispatcher
 
-  implicit val conf: FcmSettings = FcmSettings()
+  implicit val conf = FcmSettings()
   implicit val settings: GoogleSettings = GoogleSettings().copy(projectId = "projectId")
 
   "FcmSender" should {

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/GraphStageCompanion.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/GraphStageCompanion.scala
@@ -9,8 +9,10 @@
 
 package org.apache.pekko.stream.connectors.jms.impl
 
-import org.apache.pekko.stream.Materializer
-import org.apache.pekko.stream.connectors.jms.Destination
+import org.apache.pekko
+import pekko.annotation.InternalApi
+import pekko.stream.Materializer
+import pekko.stream.connectors.jms.Destination
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -18,7 +20,8 @@ import scala.concurrent.duration.FiniteDuration
  * Exposes some protected methods from [[org.apache.pekko.stream.stage.GraphStage]]
  * that are not accessible when using Scala3 compiler.
  */
-private trait GraphStageCompanion {
+@InternalApi
+private[impl] trait GraphStageCompanion {
   def graphStageMaterializer: Materializer
 
   def graphStageDestination: Destination

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/GraphStageCompanion.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/GraphStageCompanion.scala
@@ -17,7 +17,7 @@ import pekko.stream.connectors.jms.Destination
 import scala.concurrent.duration.FiniteDuration
 
 /**
- * Exposes some protected methods from [[org.apache.pekko.stream.stage.GraphStage]]
+ * Exposes some protected methods from [[pekko.stream.stage.GraphStage]]
  * that are not accessible when using Scala3 compiler.
  */
 @InternalApi

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/GraphStageCompanion.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/GraphStageCompanion.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package org.apache.pekko.stream.connectors.jms.impl
+
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.jms.Destination
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Exposes some protected methods from [[org.apache.pekko.stream.stage.GraphStage]]
+ * that are not accessible when using Scala3 compiler.
+ */
+private trait GraphStageCompanion {
+  def graphStageMaterializer: Materializer
+
+  def graphStageDestination: Destination
+
+  def scheduleOnceOnGraphStage(timerKey: Any, delay: FiniteDuration): Unit
+
+  def isTimerActiveOnGraphStage(timerKey: Any): Boolean
+
+  def cancelTimerOnGraphStage(timerKey: Any): Unit
+}

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsAckSourceStage.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsAckSourceStage.scala
@@ -49,7 +49,7 @@ private[jms] final class JmsAckSourceStage(settings: JmsConsumerSettings, destin
         createDestination: jms.Session => javax.jms.Destination): JmsAckSession = {
       val session =
         connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.ClientAcknowledge).mode)
-      new JmsAckSession(connection, session, createDestination(session), destination, maxPendingAcks)
+      new JmsAckSession(connection, session, createDestination(session), graphStageDestination, maxPendingAcks)
     }
 
     protected def pushMessage(msg: AckEnvelope): Unit = push(out, msg)

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsConsumerStage.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsConsumerStage.scala
@@ -52,7 +52,7 @@ private[jms] final class JmsConsumerStage(settings: JmsConsumerSettings, destina
         createDestination: jms.Session => javax.jms.Destination): JmsConsumerSession = {
       val session =
         connection.createSession(false, settings.acknowledgeMode.getOrElse(AcknowledgeMode.AutoAcknowledge).mode)
-      new JmsConsumerSession(connection, session, createDestination(session), destination)
+      new JmsConsumerSession(connection, session, createDestination(session), graphStageDestination)
     }
 
     protected def pushMessage(msg: jms.Message): Unit = {

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsProducerStage.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsProducerStage.scala
@@ -23,9 +23,10 @@ import pekko.stream.impl.Buffer
 import pekko.stream.scaladsl.Source
 import pekko.stream.stage._
 import pekko.util.OptionVal
-import javax.jms
 
+import javax.jms
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NoStackTrace
 import scala.util.{ Failure, Success, Try }
 
@@ -34,7 +35,7 @@ import scala.util.{ Failure, Success, Try }
  */
 @InternalApi
 private trait JmsProducerConnector extends JmsConnector[JmsProducerSession] {
-  this: TimerGraphStageLogic with StageLogging =>
+  this: TimerGraphStageLogic with GraphStageCompanion with StageLogging =>
 
   protected final def createSession(connection: jms.Connection,
       createDestination: jms.Session => jms.Destination): JmsProducerSession = {
@@ -74,7 +75,18 @@ private[jms] final class JmsProducerStage[E <: JmsEnvelope[PassThrough], PassThr
   }
 
   private def producerLogic(inheritedAttributes: Attributes) =
-    new TimerGraphStageLogic(shape) with JmsProducerConnector with StageLogging {
+    new TimerGraphStageLogic(shape) with JmsProducerConnector with GraphStageCompanion with StageLogging {
+
+      final override def graphStageMaterializer: Materializer = materializer
+
+      final override def graphStageDestination: Destination = destination
+
+      final override def scheduleOnceOnGraphStage(timerKey: Any, delay: FiniteDuration): Unit =
+        scheduleOnce(timerKey, delay)
+
+      final override def isTimerActiveOnGraphStage(timerKey: Any): Boolean = isTimerActive(timerKey)
+
+      final override def cancelTimerOnGraphStage(timerKey: Any): Unit = cancelTimer(timerKey)
 
       /*
        * NOTE: the following code is heavily inspired by akka.stream.impl.fusing.MapAsync

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsTxSourceStage.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsTxSourceStage.scala
@@ -46,7 +46,7 @@ private[jms] final class JmsTxSourceStage(settings: JmsConsumerSettings, destina
     protected def createSession(connection: jms.Connection, createDestination: jms.Session => javax.jms.Destination) = {
       val session =
         connection.createSession(true, settings.acknowledgeMode.getOrElse(AcknowledgeMode.SessionTransacted).mode)
-      new JmsConsumerSession(connection, session, createDestination(session), this.asInstanceOf[JmsTxSourceStage].destination)
+      new JmsConsumerSession(connection, session, createDestination(session), graphStageDestination)
     }
 
     protected def pushMessage(msg: TxEnvelope): Unit = push(out, msg)

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsTxSourceStage.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsTxSourceStage.scala
@@ -46,7 +46,7 @@ private[jms] final class JmsTxSourceStage(settings: JmsConsumerSettings, destina
     protected def createSession(connection: jms.Connection, createDestination: jms.Session => javax.jms.Destination) = {
       val session =
         connection.createSession(true, settings.acknowledgeMode.getOrElse(AcknowledgeMode.SessionTransacted).mode)
-      new JmsConsumerSession(connection, session, createDestination(session), destination)
+      new JmsConsumerSession(connection, session, createDestination(session), this.asInstanceOf[JmsTxSourceStage].destination)
     }
 
     protected def pushMessage(msg: TxEnvelope): Unit = push(out, msg)

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/SourceStageLogic.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/SourceStageLogic.scala
@@ -13,7 +13,6 @@
 
 package org.apache.pekko.stream.connectors.jms.impl
 
-import java.util.concurrent.atomic.AtomicBoolean
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream.connectors.jms.impl.InternalConnectionState.JmsConnectorStopping
@@ -23,9 +22,10 @@ import pekko.stream.stage.{ OutHandler, StageLogging, TimerGraphStageLogic }
 import pekko.stream.{ Attributes, Materializer, Outlet, SourceShape }
 import pekko.{ Done, NotUsed }
 
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.jms
 import scala.collection.mutable
 import scala.util.{ Failure, Success }
-import javax.jms
 import scala.concurrent.duration.FiniteDuration
 
 /**

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/SourceStageLogic.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/SourceStageLogic.scala
@@ -14,27 +14,26 @@
 package org.apache.pekko.stream.connectors.jms.impl
 
 import java.util.concurrent.atomic.AtomicBoolean
-
 import org.apache.pekko
 import pekko.annotation.InternalApi
 import pekko.stream.connectors.jms.impl.InternalConnectionState.JmsConnectorStopping
 import pekko.stream.connectors.jms.{ Destination, JmsConsumerSettings }
 import pekko.stream.scaladsl.Source
 import pekko.stream.stage.{ OutHandler, StageLogging, TimerGraphStageLogic }
-import pekko.stream.{ Attributes, Outlet, SourceShape }
+import pekko.stream.{ Attributes, Materializer, Outlet, SourceShape }
 import pekko.{ Done, NotUsed }
 
 import scala.collection.mutable
 import scala.util.{ Failure, Success }
-
 import javax.jms
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * Internal API.
  */
 @InternalApi
 private trait JmsConsumerConnector extends JmsConnector[JmsConsumerSession] {
-  this: TimerGraphStageLogic with StageLogging =>
+  this: TimerGraphStageLogic with GraphStageCompanion with StageLogging =>
 
   override val startConnection = true
 
@@ -54,7 +53,19 @@ private abstract class SourceStageLogic[T](shape: SourceShape[T],
     inheritedAttributes: Attributes)
     extends TimerGraphStageLogic(shape)
     with JmsConsumerConnector
+    with GraphStageCompanion
     with StageLogging {
+
+  final override def graphStageMaterializer: Materializer = materializer
+
+  final override def graphStageDestination: Destination = destination
+
+  final override def scheduleOnceOnGraphStage(timerKey: Any, delay: FiniteDuration): Unit =
+    scheduleOnce(timerKey, delay)
+
+  final override def isTimerActiveOnGraphStage(timerKey: Any): Boolean = isTimerActive(timerKey)
+
+  final override def cancelTimerOnGraphStage(timerKey: Any): Unit = cancelTimer(timerKey)
 
   override protected def jmsSettings: JmsConsumerSettings = settings
   private val queue = mutable.Queue[T]()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -106,6 +106,7 @@ object Dependencies {
         ExclusionRule("software.amazon.awssdk", "netty-nio-client"))) ++ Mockito)
 
   val AzureStorageQueue = Seq(
+    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "com.microsoft.azure" % "azure-storage" % "8.0.0" // ApacheV2
     ))
@@ -115,6 +116,7 @@ object Dependencies {
   val CassandraDriverVersionInDocs = "4.15"
 
   val Cassandra = Seq(
+    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       ("com.datastax.oss" % "java-driver-core" % CassandraDriverVersion)
         .exclude("com.github.spotbugs", "spotbugs-annotations")
@@ -123,6 +125,7 @@ object Dependencies {
       "org.apache.pekko" %% "pekko-discovery" % PekkoVersion % Provided))
 
   val Couchbase = Seq(
+    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "com.couchbase.client" % "java-client" % CouchbaseVersion, // ApacheV2
       "io.reactivex" % "rxjava-reactive-streams" % "1.2.1", // ApacheV2
@@ -197,6 +200,7 @@ object Dependencies {
         "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.17.1" % Test) ++ JacksonDatabindDependencies)
 
   val GoogleCommon = Seq(
+    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-spray-json" % PekkoHttpVersion,
@@ -206,6 +210,7 @@ object Dependencies {
     ) ++ Mockito)
 
   val GoogleBigQuery = Seq(
+    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-jackson" % PekkoHttpVersion % Provided,
@@ -232,6 +237,7 @@ object Dependencies {
       "org.apache.pekko" %% "pekko-discovery" % PekkoVersion) ++ Mockito)
 
   val GooglePubSub = Seq(
+    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-spray-json" % PekkoHttpVersion,
@@ -250,6 +256,7 @@ object Dependencies {
       "org.apache.pekko" %% "pekko-discovery" % PekkoVersion))
 
   val GoogleFcm = Seq(
+    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-spray-json" % PekkoHttpVersion) ++ Mockito)
@@ -296,6 +303,7 @@ object Dependencies {
     ))
 
   val HuaweiPushKit = Seq(
+    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-spray-json" % PekkoHttpVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -324,7 +324,6 @@ object Dependencies {
     ))
 
   val Jms = Seq(
-    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "javax.jms" % "jms" % "1.1" % Provided, // CDDL + GPLv2
       "com.ibm.mq" % "com.ibm.mq.allclient" % "9.2.5.0" % Test, // IBM International Program License Agreement https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/maven/licenses/L-APIG-AZYF2E/LI_en.html

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -157,7 +157,6 @@ object Dependencies {
     ))
 
   val Elasticsearch = Seq(
-    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-spray-json" % PekkoHttpVersion,


### PR DESCRIPTION
Part of https://github.com/apache/incubator-pekko-connectors/issues/126

Scala 3 compile issues needed fixing.
* main ones were related to using protected methods on self types
* also some issues where fields were ambiguous (multiple inheritance in Scala means that a field can be declared on 2 separate traits)

I introduced a GraphStageCompanion trait to give public access to the methods that were needed to get Scala3 compile to work.