### PR TITLE
Scala3 support for mongodb connector

### DIFF
--- a/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSinkSpec.scala
@@ -15,17 +15,17 @@ package docs.scaladsl
 
 import org.apache.pekko
 import pekko.actor.ActorSystem
-import pekko.stream.connectors.mongodb.{DocumentReplace, DocumentUpdate}
+import pekko.stream.connectors.mongodb.{ DocumentReplace, DocumentUpdate }
 import pekko.stream.connectors.mongodb.scaladsl.MongoSink
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
-import pekko.stream.scaladsl.{Sink, Source}
+import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import pekko.util.ccompat.JavaConverters._
-import com.mongodb.client.model.{Filters, InsertManyOptions, Updates}
-import com.mongodb.reactivestreams.client.{MongoClients, MongoCollection}
+import com.mongodb.client.model.{ Filters, InsertManyOptions, Updates }
+import com.mongodb.reactivestreams.client.{ MongoClients, MongoCollection }
 import org.bson.Document
 import org.bson.codecs.ValueCodecProvider
-import org.bson.codecs.configuration.CodecRegistries.{fromProviders, fromRegistries}
+import org.bson.codecs.configuration.CodecRegistries.{ fromProviders, fromRegistries }
 import org.bson.codecs.pojo.PojoCodecProvider
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures

--- a/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
+++ b/mongodb/src/test/scala/docs/scaladsl/MongoSourceSpec.scala
@@ -18,7 +18,7 @@ import pekko.NotUsed
 import pekko.actor.ActorSystem
 import pekko.stream.connectors.mongodb.scaladsl.MongoSource
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
-import pekko.stream.scaladsl.{Sink, Source}
+import pekko.stream.scaladsl.{ Sink, Source }
 import pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import pekko.util.ccompat.JavaConverters._
 import com.mongodb.reactivestreams.client.MongoClients

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -355,8 +355,9 @@ object Dependencies {
 
   val MongoDb = Seq(
     libraryDependencies ++= Seq(
-      "org.mongodb.scala" % "mongo-java-driver" % "4.9.0" // ApacheV2
-    ))
+      "org.mongodb" % "mongodb-driver-core" % "4.9.1", // ApacheV2
+      "org.mongodb" % "mongodb-driver-reactivestreams" % "4.9.1" // ApacheV2
+  ))
 
   val Mqtt = Seq(
     libraryDependencies ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -357,7 +357,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "org.mongodb" % "mongodb-driver-core" % "4.9.1", // ApacheV2
       "org.mongodb" % "mongodb-driver-reactivestreams" % "4.9.1" // ApacheV2
-  ))
+    ))
 
   val Mqtt = Seq(
     libraryDependencies ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -354,9 +354,8 @@ object Dependencies {
     ))
 
   val MongoDb = Seq(
-    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
-      "org.mongodb.scala" %% "mongo-scala-driver" % "4.4.0" // ApacheV2
+      "org.mongodb.scala" % "mongo-java-driver" % "4.9.0" // ApacheV2
     ))
 
   val Mqtt = Seq(


### PR DESCRIPTION
Mongodb have abandoned their Scala support and never released a Scala3 compatible jar.

https://github.com/mongodb/mongo-scala-driver/