### PR TITLE
support scala3 for amqp connector

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,7 +89,6 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-databind" % JacksonDatabindVersion)
 
   val Amqp = Seq(
-    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "com.rabbitmq" % "amqp-client" % "5.14.2" // APLv2
     ) ++ Mockito)


### PR DESCRIPTION
main issue is that Scala3 is stricter about accessing class fields during recursion

part of #126 