### PR TITLE
Scala3 hdfs

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -281,11 +281,10 @@ object Dependencies {
 
   val HadoopVersion = "3.2.1"
   val Hdfs = Seq(
-    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       ("org.apache.hadoop" % "hadoop-client" % HadoopVersion).exclude("log4j", "log4j").exclude("org.slf4j",
         "slf4j-log4j12"), // ApacheV2
-      "org.typelevel" %% "cats-core" % "2.0.0", // MIT,
+      "org.typelevel" %% "cats-core" % "2.9.0", // MIT,
       ("org.apache.hadoop" % "hadoop-hdfs" % HadoopVersion % Test).exclude("log4j", "log4j").exclude("org.slf4j",
         "slf4j-log4j12"), // ApacheV2
       ("org.apache.hadoop" % "hadoop-common" % HadoopVersion % Test).exclude("log4j", "log4j").exclude("org.slf4j",


### PR DESCRIPTION
need newer version of cats-core - as old one does not support scala3

part of #126 