### PR TITLE
upgrade grpc plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,6 +26,6 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 // Pekko gRPC -- sync with version in Dependencies.scala:19
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % "0.0.0-45-fdf9da1b-SNAPSHOT")
+addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % "0.0.0-41-ab1c00da-SNAPSHOT")
 // templating
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,6 +26,6 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 // Pekko gRPC -- sync with version in Dependencies.scala:19
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % "0.0.0-28-e757bd9d-SNAPSHOT")
+addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % "0.0.0-45-fdf9da1b-SNAPSHOT")
 // templating
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")


### PR DESCRIPTION
Seems tidiest to upgrade to newer snapshot.

It is contributing to some issues migrating the connectors that need grpc to support scala 3.