### PR TITLE
Scala3 mqtt streaming

### DIFF
--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/model.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/model.scala
@@ -53,7 +53,8 @@ object ControlPacketType {
   val DISCONNECT = ControlPacketType(14)
   val Reserved2 = ControlPacketType(15)
 }
-final case class ControlPacketType private (underlying: Int) extends AnyVal
+@InternalApi
+final case class ControlPacketType(underlying: Int) extends AnyVal
 
 /**
  * 2.2.2 Flags
@@ -75,7 +76,8 @@ object ControlPacketFlags {
   val RETAIN = ControlPacketFlags(1)
 }
 
-final case class ControlPacketFlags private (underlying: Int) extends AnyVal {
+@InternalApi
+final case class ControlPacketFlags(underlying: Int) extends AnyVal {
 
   /**
    * Convenience bitwise OR
@@ -110,7 +112,8 @@ case object Reserved2 extends ControlPacket(ControlPacketType.Reserved2, Control
  * 2.3.1 Packet Identifier
  * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
  */
-final case class PacketId private (underlying: Int) extends AnyVal
+@InternalApi
+final case class PacketId(underlying: Int) extends AnyVal
 
 object ConnectFlags {
   val None = ConnectFlags(0)
@@ -127,7 +130,7 @@ object ConnectFlags {
  * 3.1.2.3 Connect Flags
  * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
  */
-final case class ConnectFlags private (underlying: Int) extends AnyVal {
+final case class ConnectFlags private[streaming] (underlying: Int) extends AnyVal {
 
   /**
    * Convenience bitwise OR
@@ -223,7 +226,7 @@ object ConnAckFlags {
  * 3.2.2.1 Connect Acknowledge Flags
  * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
  */
-final case class ConnAckFlags private (underlying: Int) extends AnyVal
+final case class ConnAckFlags private[streaming] (underlying: Int) extends AnyVal
 
 object ConnAckReturnCode {
   val ConnectionAccepted = ConnAckReturnCode(0)
@@ -238,7 +241,7 @@ object ConnAckReturnCode {
  * 3.2.2.3 Connect Return code
  * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
  */
-final case class ConnAckReturnCode private (underlying: Int) extends AnyVal {
+final case class ConnAckReturnCode private[streaming] (underlying: Int) extends AnyVal {
 
   /**
    * Convenience bitwise OR
@@ -286,7 +289,8 @@ object Publish {
  * 3.3 PUBLISH – Publish message
  * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
  */
-final case class Publish @InternalApi private[streaming] (override val flags: ControlPacketFlags,
+@InternalApi
+final case class Publish(override val flags: ControlPacketFlags,
     topicName: String,
     packetId: Option[PacketId],
     payload: ByteString)

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/scaladsl/MqttSession.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/scaladsl/MqttSession.scala
@@ -169,7 +169,7 @@ final class ActorMqttClientSession(settings: MqttSessionSettings)(implicit syste
   import MqttSession._
   import system.dispatcher
 
-  private implicit val loggingAdapter: LoggingAdapter = Logging(system, this.getClass)
+  private implicit val loggingAdapter: LoggingAdapter = Logging(system, classOf[ActorMqttClientSession])
 
   override def ![A](cp: Command[A]): Unit = cp match {
     case Command(cp: Publish, _, carry) =>
@@ -504,7 +504,7 @@ final class ActorMqttServerSession(settings: MqttSessionSettings)(implicit syste
   import MqttSession._
   import system.dispatcher
 
-  private implicit val loggingAdapter: LoggingAdapter = Logging(system, this.getClass)
+  private implicit val loggingAdapter: LoggingAdapter = Logging(system, classOf[ActorMqttClientSession])
 
   override def ![A](cp: Command[A]): Unit = cp match {
     case Command(cp: Publish, _, carry) =>

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -45,7 +45,8 @@ class TypedMqttFlowSpec
       "typed-flow-spec/topic1",
       org.apache.pekko.actor.typed.ActorSystem(Behaviors.ignore, "TypedMqttFlowSpec").toClassic)
 
-abstract class MqttFlowSpecBase(val clientId: String, val topic: String, system: ActorSystem) extends TestKit(system) with AnyWordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
+abstract class MqttFlowSpecBase(val clientId: String, val topic: String, system: ActorSystem) extends TestKit(system)
+    with AnyWordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
 
   override def sourceActorSytem = Some(system.name)
 
@@ -56,7 +57,6 @@ abstract class MqttFlowSpecBase(val clientId: String, val topic: String, system:
   private implicit val implicitSystem: ActorSystem = system
 
   implicit val logAdapter: LoggingAdapter = Logging(system, this.getClass.getName)
-
 
   override def afterAll(): Unit =
     TestKit.shutdownActorSystem(system)

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -45,7 +45,7 @@ class TypedMqttFlowSpec
       "typed-flow-spec/topic1",
       pekko.actor.typed.ActorSystem(Behaviors.ignore, "TypedMqttFlowSpec").toClassic)
 
-abstract class MqttFlowSpecBase(val clientId: String, val topic: String, system: ActorSystem) extends TestKit(system)
+abstract class MqttFlowSpecBase(clientId: String, topic: String, system: ActorSystem) extends TestKit(system)
     with AnyWordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
 
   override def sourceActorSytem = Some(system.name)

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -36,37 +36,37 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class UntypedMqttFlowSpec
-    extends ParametrizedTestKit("untyped-flow-spec/flow",
+    extends ParameterizedTestKit("untyped-flow-spec/flow",
       "untyped-flow-spec/topic1",
       ActorSystem("UntypedMqttFlowSpec"))
     with MqttFlowSpec
 class TypedMqttFlowSpec
-    extends ParametrizedTestKit("typed-flow-spec/flow",
+    extends ParameterizedTestKit("typed-flow-spec/flow",
       "typed-flow-spec/topic1",
       org.apache.pekko.actor.typed.ActorSystem(Behaviors.ignore, "TypedMqttFlowSpec").toClassic)
     with MqttFlowSpec
 
-class ParametrizedTestKit(val clientId: String, val topic: String, system: ActorSystem) extends TestKit(system)
+class ParameterizedTestKit(val clientId: String, val topic: String, system: ActorSystem) extends TestKit(system)
 
 trait MqttFlowSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {
-  self: ParametrizedTestKit =>
+  self: ParameterizedTestKit =>
 
-  override def sourceActorSytem = Some(system.name)
+  override def sourceActorSytem = Some(this.system.name)
 
   private implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = 5.seconds, interval = 100.millis)
 
-  private implicit val dispatcherExecutionContext: ExecutionContext = system.dispatcher
+  private implicit val dispatcherExecutionContext: ExecutionContext = this.system.dispatcher
 
-  implicit val logAdapter: LoggingAdapter = Logging(system, this.getClass.getName)
+  implicit val logAdapter: LoggingAdapter = Logging(this.system, this.getClass.getName)
 
   override def afterAll(): Unit =
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(this.system)
 
   "mqtt client flow" should {
     "establish a bidirectional connection and subscribe to a topic" in assertAllStagesStopped {
       // #create-streaming-flow
       val settings = MqttSessionSettings()
-      val session = ActorMqttClientSession(settings)
+      val session = ActorMqttClientSession(settings)(this.system)
 
       val connection = Tcp().outgoingConnection("localhost", 1883)
 

--- a/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
+++ b/mqtt-streaming/src/test/scala/docs/scaladsl/MqttFlowSpec.scala
@@ -43,7 +43,7 @@ class UntypedMqttFlowSpec
 class TypedMqttFlowSpec
     extends MqttFlowSpecBase("typed-flow-spec/flow",
       "typed-flow-spec/topic1",
-      org.apache.pekko.actor.typed.ActorSystem(Behaviors.ignore, "TypedMqttFlowSpec").toClassic)
+      pekko.actor.typed.ActorSystem(Behaviors.ignore, "TypedMqttFlowSpec").toClassic)
 
 abstract class MqttFlowSpecBase(val clientId: String, val topic: String, system: ActorSystem) extends TestKit(system)
     with AnyWordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures with LogCapturing {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -365,7 +365,6 @@ object Dependencies {
     ))
 
   val MqttStreaming = Seq(
-    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-actor-typed" % PekkoVersion, // ApacheV2
       "org.apache.pekko" %% "pekko-actor-testkit-typed" % PekkoVersion % Test, // ApacheV2


### PR DESCRIPTION
part of #126 

The main problems
* Scala 3 is stricter about private fields/functions - some tests are in `docs.scaladsl` and somehow Scala 2 lets that have access to private fields - Scala 3 cares about this - I had to make some stuff public and mark them as `@InternalApi`
* MqttFlowSpec had to be changed. Scala 3 does not allow access to some stuff on self types - including implicits
  * since it is test code and it was easy to get rid of the self type, that seemed the easiest solution (I had tried a number of other ways without success) 