### PR TITLE
Add commands to apply and check codestyle

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -41,8 +41,8 @@ jobs:
         uses: coursier/cache-action@v6.4.0
 
       # temporarily remove mima checks
-      - name: "Code style, compile tests, MiMa. Run locally with: sbt +~2.13 \"verifyCodeFmt; Test/compile; mimaReportBinaryIssues\""
-        run: sbt "verifyCodeFmt; +Test/compile"
+      - name: "Code style, compile tests, MiMa. Run locally with: sbt +~2.13 \"javafmtCheckAll; Test/compile; mimaReportBinaryIssues\""
+        run: sbt "javafmtCheckAll; +Test/compile"
 
   documentation:
     name: ScalaDoc, Documentation with Paradox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,12 @@ Example:
     * Details 2
     * Details 3
 
+## Applying code style to the project
+
+The project uses [scalafmt](https://scalameta.org/scalafmt/) to ensure code quality which is automatically checked on
+every PR. If you would like to check for any potential code style problems locally you can run `sbt checkCodeStyle`
+and if you want to apply the code style then you can run `sbt applyCodeStyle`.
+
 ### Ignoring formatting commits in git blame
 
 Throughout the history of the codebase various formatting commits have been applied as the scalafmt style has evolved over time, if desired

--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,11 @@ lazy val `pekko-connectors` = project
         |
         |  mimaReportBinaryIssues - checks whether this current API
         |    is binary compatible with the released version
+        |
+        |  checkCodeStyle - checks that the codebase follows code
+        |    style
+        |
+        |  applyCodeStyle - applies code style to the codebase
       """.stripMargin,
     // unidoc combines sources and jars from all connectors and that
     // might include some incompatible ones. Depending on the
@@ -124,12 +129,8 @@ lazy val `pekko-connectors` = project
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465
   )
 
-TaskKey[Unit]("verifyCodeFmt") := {
-  javafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
-    throw new MessageOnlyException(
-      "Unformatted Java code found. Please run 'javafmtAll' and commit the reformatted code")
-  }
-}
+addCommandAlias("applyCodeStyle", ";scalafmtAll; scalafmtSbt; javafmtAll")
+addCommandAlias("checkCodeStyle", ";scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll")
 
 lazy val amqp = pekkoConnectorProject("amqp", "amqp", Dependencies.Amqp)
 


### PR DESCRIPTION
As can be seen from https://github.com/apache/incubator-pekko-connectors/pull/205#issuecomment-1657823432 users unfamiliar to the codebase are having issues both checking/applying scalafmt and javafmt to the codebase