### PR TITLE
sbt-source-dist 0.1.10

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.31")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
-addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.8")
+addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.10")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 // discipline
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")


### PR DESCRIPTION
switches to just publishing a tgz release (no zip)