### PR TITLE
add paho license

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,7 +12,7 @@ Apache License, Version 2.0 License.
 
 ---------------
 
-pekko-connectors-s3 contains code aws-sdk-java <from https://github.com/aws/aws-sdk-java>.
+pekko-connectors-s3 contains code from aws-sdk-java <https://github.com/aws/aws-sdk-java>.
 This code was released under an Apache 2.0 license.
 
 AWS SDK for Java

--- a/build.sbt
+++ b/build.sbt
@@ -288,7 +288,9 @@ lazy val mongodb = pekkoConnectorProject("mongodb", "mongodb", Dependencies.Mong
 lazy val mqtt = pekkoConnectorProject("mqtt", "mqtt", Dependencies.Mqtt)
 
 lazy val mqttStreaming =
-  pekkoConnectorProject("mqtt-streaming", "mqttStreaming", Dependencies.MqttStreaming)
+  pekkoConnectorProject("mqtt-streaming", "mqttStreaming", Dependencies.MqttStreaming,
+    MetaInfLicenseNoticeCopy.mqttStreamingSettings)
+
 lazy val mqttStreamingBench = internalProject("mqtt-streaming-bench")
   .enablePlugins(JmhPlugin)
   .dependsOn(mqtt, mqttStreaming)

--- a/legal/MqttStreamingLicense.txt
+++ b/legal/MqttStreamingLicense.txt
@@ -222,13 +222,3 @@ and the Eclipse Distribution License is available at
 
 For an explanation of what dual-licensing means to you, see:
 https://www.eclipse.org/legal/eplfaq.php#DUALLIC
-
----------------
-
-pekko-connectors-s3 contains code from aws-sdk-java <https://github.com/aws/aws-sdk-java>.
-This code was released under an Apache 2.0 license.
-
- - s3/src/main/scala/org/apache/pekko/stream/connectors/s3/Utils.scala
-
-AWS SDK for Java
-Copyright 2010-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/legal/S3License.txt
+++ b/legal/S3License.txt
@@ -202,7 +202,7 @@
 
 ---------------
 
-pekko-connectors-s3 contains code aws-sdk-java <from https://github.com/aws/aws-sdk-java>.
+pekko-connectors-s3 contains code from aws-sdk-java <https://github.com/aws/aws-sdk-java>.
 This code was released under an Apache 2.0 license.
 
  - s3/src/main/scala/org/apache/pekko/stream/connectors/s3/Utils.scala

--- a/legal/S3Notice.txt
+++ b/legal/S3Notice.txt
@@ -12,7 +12,7 @@ Apache License, Version 2.0 License.
 
 ---------------
 
-pekko-connectors-s3 contains code aws-sdk-java <from https://github.com/aws/aws-sdk-java>.
+pekko-connectors-s3 contains code from aws-sdk-java <https://github.com/aws/aws-sdk-java>.
 This code was released under an Apache 2.0 license.
 
 AWS SDK for Java

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/impl/RequestState.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/impl/RequestState.scala
@@ -11,7 +11,7 @@
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 
-/*******************************************************************************
+/**
  * Copyright (c) 2009, 2014 IBM Corp.
  *
  * All rights reserved. This program and the accompanying materials

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/impl/RequestState.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/impl/RequestState.scala
@@ -11,6 +11,22 @@
  * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
  */
 
+/*******************************************************************************
+ * Copyright (c) 2009, 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0
+ * and the Eclipse Distribution License is available at
+ *   https://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *    Dave Locke - initial API and implementation and/or initial documentation
+ */
+
 package org.apache.pekko.stream.connectors.mqtt.streaming
 package impl
 
@@ -615,7 +631,10 @@ object Topics {
    * 4.7 Topic Names and Topic Filters
    * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
    *
-   * Inspired by https://github.com/eclipse/paho.mqtt.java/blob/master/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttTopic.java#L240
+   * Inspired by https://github.com/eclipse/paho.mqtt.java/blob/master/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttTopic.java
+   *
+   * The Apache Pekko project chooses to use the paho.mqtt.java inspired code under the
+   * Eclipse Distribution License <https://www.eclipse.org/org/documents/edl-v10.php>
    */
   def filter(topicFilterName: String, topicName: String): Boolean = {
     @tailrec

--- a/project/MetaInfLicenseNoticeCopy.scala
+++ b/project/MetaInfLicenseNoticeCopy.scala
@@ -32,6 +32,9 @@ object MetaInfLicenseNoticeCopy extends AutoPlugin {
     apacheSonatypeNoticeFile := baseDir.value / "legal" / "PekkoConnectorsNotice.txt",
     apacheSonatypeDisclaimerFile := Some(baseDir.value / "DISCLAIMER"))
 
+  lazy val mqttStreamingSettings = Seq(
+    apacheSonatypeLicenseFile := baseDir.value / "legal" / "MqttStreamingLicense.txt")
+
   lazy val s3Settings = Seq(
     apacheSonatypeLicenseFile := baseDir.value / "legal" / "S3License.txt",
     apacheSonatypeNoticeFile := baseDir.value / "legal" / "S3Notice.txt")


### PR DESCRIPTION
* also fixes some typos in a recent S3 license/notice PR
* Because paho is dual licensed, I've chosen the more permissive Eclipse Distribution License
  * see https://www.apache.org/legal/resolved.html (Eclipse Distribution License is category A while Eclipse Public License is category B).

Fixes https://github.com/apache/incubator-pekko-connectors/issues/184