### PR TITLE
Update to latest pekko-grpc-sbt-plugin snapshot

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -36,7 +36,7 @@ addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-project-info" % "2.0.0").fo
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
-// Pekko gRPC -- sync with version in Dependencies.scala:19
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % "0.0.0-73-c03eff2b-SNAPSHOT")
+// Pekko gRPC -- sync with version in Dependencies.scala:29
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.0-RC1-3-ae23c14d-SNAPSHOT")
 // templating
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")


### PR DESCRIPTION
Latest pekko-grpc has a different artifact name for the sbt plugin