### PR TITLE
FTP: Add a setting to enable automatic server encoding detection

### DIFF
--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/FtpOperations.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/FtpOperations.scala
@@ -28,6 +28,10 @@ private[ftp] trait FtpOperations extends CommonFtpOperations { _: FtpLike[FTPCli
   def connect(connectionSettings: FtpSettings)(implicit ftpClient: FTPClient): Try[Handler] = Try {
     connectionSettings.proxy.foreach(ftpClient.setProxy)
 
+    if (ftpClient.getAutodetectUTF8() != connectionSettings.autodetectUTF8) {
+      ftpClient.setAutodetectUTF8(connectionSettings.autodetectUTF8)
+    }
+
     try {
       ftpClient.connect(connectionSettings.host, connectionSettings.port)
     } catch {

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/FtpsOperations.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/FtpsOperations.scala
@@ -31,6 +31,10 @@ private[ftp] trait FtpsOperations extends CommonFtpOperations {
     Try {
       connectionSettings.proxy.foreach(ftpClient.setProxy)
 
+      if (ftpClient.getAutodetectUTF8() != connectionSettings.autodetectUTF8) {
+        ftpClient.setAutodetectUTF8(connectionSettings.autodetectUTF8)
+      }
+
       ftpClient.connect(connectionSettings.host, connectionSettings.port)
 
       connectionSettings.configureConnection(ftpClient)

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/model.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/model.scala
@@ -68,6 +68,8 @@ abstract sealed class FtpFileSettings extends RemoteFileSettings {
  * @param credentials credentials (username and password)
  * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
+ * @param autodetectUTF8 enables or disables automatic server encoding detection (only UTF-8 supported).
+ *                       Disabled by default (false).
  * @param configureConnection A function which will be called after connecting to the server. Use this for
  *                            any custom configuration required by the server you are connecting to.
  * @param proxy An optional proxy to use when connecting with these settings
@@ -78,6 +80,7 @@ final class FtpSettings private (
     val credentials: FtpCredentials,
     val binary: Boolean,
     val passiveMode: Boolean,
+    val autodetectUTF8: Boolean,
     val configureConnection: FTPClient => Unit,
     val proxy: Option[Proxy]) extends FtpFileSettings {
 
@@ -87,6 +90,8 @@ final class FtpSettings private (
   def withBinary(value: Boolean): FtpSettings = if (binary == value) this else copy(binary = value)
   def withPassiveMode(value: Boolean): FtpSettings =
     if (passiveMode == value) this else copy(passiveMode = value)
+  def withAutodetectUTF8(value: Boolean): FtpSettings =
+    if (autodetectUTF8 == value) this else copy(autodetectUTF8 = value)
   def withProxy(value: Proxy): FtpSettings = copy(proxy = Some(value))
 
   /**
@@ -110,6 +115,7 @@ final class FtpSettings private (
       credentials: FtpCredentials = credentials,
       binary: Boolean = binary,
       passiveMode: Boolean = passiveMode,
+      autodetectUTF8: Boolean = autodetectUTF8,
       configureConnection: FTPClient => Unit = configureConnection,
       proxy: Option[Proxy] = proxy): FtpSettings = new FtpSettings(
     host = host,
@@ -117,6 +123,7 @@ final class FtpSettings private (
     credentials = credentials,
     binary = binary,
     passiveMode = passiveMode,
+    autodetectUTF8 = autodetectUTF8,
     configureConnection = configureConnection,
     proxy = proxy)
 
@@ -127,6 +134,7 @@ final class FtpSettings private (
     s"credentials=$credentials," +
     s"binary=$binary," +
     s"passiveMode=$passiveMode," +
+    s"autodetectUTF8=$autodetectUTF8" +
     s"configureConnection=$configureConnection," +
     s"proxy=$proxy)"
 }
@@ -146,6 +154,7 @@ object FtpSettings {
     credentials = FtpCredentials.AnonFtpCredentials,
     binary = false,
     passiveMode = false,
+    autodetectUTF8 = false,
     configureConnection = _ => (),
     proxy = None)
 
@@ -162,6 +171,8 @@ object FtpSettings {
  * @param credentials credentials (username and password)
  * @param binary specifies the file transfer mode, BINARY or ASCII. Default is ASCII (false)
  * @param passiveMode specifies whether to use passive mode connections. Default is active mode (false)
+ * @param autodetectUTF8 enables or disables automatic server encoding detection (only UTF-8 supported).
+ *                       Disabled by default (false).
  * @param configureConnection A function which will be called after connecting to the server. Use this for
  *                            any custom configuration required by the server you are connecting to.
  * @param proxy An optional proxy to use when connecting with these settings
@@ -172,6 +183,7 @@ final class FtpsSettings private (
     val credentials: FtpCredentials,
     val binary: Boolean,
     val passiveMode: Boolean,
+    val autodetectUTF8: Boolean,
     val configureConnection: FTPSClient => Unit,
     val proxy: Option[Proxy]) extends FtpFileSettings {
 
@@ -181,6 +193,8 @@ final class FtpsSettings private (
   def withBinary(value: Boolean): FtpsSettings = if (binary == value) this else copy(binary = value)
   def withPassiveMode(value: Boolean): FtpsSettings =
     if (passiveMode == value) this else copy(passiveMode = value)
+  def withAutodetectUTF8(value: Boolean): FtpsSettings =
+    if (autodetectUTF8 == value) this else copy(autodetectUTF8 = value)
   def withProxy(value: Proxy): FtpsSettings = copy(proxy = Some(value))
 
   /**
@@ -204,6 +218,7 @@ final class FtpsSettings private (
       credentials: FtpCredentials = credentials,
       binary: Boolean = binary,
       passiveMode: Boolean = passiveMode,
+      autodetectUTF8: Boolean = autodetectUTF8,
       configureConnection: FTPSClient => Unit = configureConnection,
       proxy: Option[Proxy] = proxy): FtpsSettings = new FtpsSettings(
     host = host,
@@ -211,6 +226,7 @@ final class FtpsSettings private (
     credentials = credentials,
     binary = binary,
     passiveMode = passiveMode,
+    autodetectUTF8 = autodetectUTF8,
     configureConnection = configureConnection,
     proxy = proxy)
 
@@ -221,6 +237,7 @@ final class FtpsSettings private (
     s"credentials=$credentials," +
     s"binary=$binary," +
     s"passiveMode=$passiveMode," +
+    s"autodetectUTF8=$autodetectUTF8" +
     s"configureConnection=$configureConnection," +
     s"proxy=$proxy)"
 }
@@ -240,6 +257,7 @@ object FtpsSettings {
     FtpCredentials.AnonFtpCredentials,
     binary = false,
     passiveMode = false,
+    autodetectUTF8 = false,
     configureConnection = _ => (),
     proxy = None)
 


### PR DESCRIPTION
Resolves #216 by adding a method to FtpSettings and FtpsSettings to enable or disable automatic server encoding detection. 