### PR TITLE
Add scala3 support to Azure Storage Queue

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -101,7 +101,6 @@ object Dependencies {
         ExclusionRule("software.amazon.awssdk", "netty-nio-client"))) ++ Mockito)
 
   val AzureStorageQueue = Seq(
-    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "com.microsoft.azure" % "azure-storage" % "8.0.0"))
 


### PR DESCRIPTION
Either this may have been missed or we are lucky because the azure-storage-queue compiles with Scala 3 fine 