### PR TITLE
grpc 1.0.0 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,10 @@
 
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 
+// TODO: Remove when Pekko has a proper release
+ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
+ThisBuild / updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 ThisBuild / apacheSonatypeProjectProfile := "pekko"
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := true

--- a/build.sbt
+++ b/build.sbt
@@ -9,11 +9,6 @@
 
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 
-// TODO: Remove when Pekko has a proper release
-ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
-ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
-ThisBuild / updateOptions := updateOptions.value.withLatestSnapshots(false)
-
 ThisBuild / apacheSonatypeProjectProfile := "pekko"
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -37,6 +37,6 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 // Pekko gRPC -- sync with version in Dependencies.scala:29
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.0-RC1-3-ae23c14d-SNAPSHOT")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.0")
 // templating
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")


### PR DESCRIPTION
we still need to have the snapshot resolver because of the pekko-sbt-paradox plugin and pekko-material-theme