### PR TITLE
Remove Apache snapshot repository

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,10 +9,6 @@
 
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 
-// TODO: Remove when Pekko has a proper release
-ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
-ThisBuild / updateOptions := updateOptions.value.withLatestSnapshots(false)
-
 ThisBuild / apacheSonatypeProjectProfile := "pekko"
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := true
@@ -351,6 +347,9 @@ lazy val docs = project
   .enablePlugins(PekkoParadoxPlugin, ParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin)
   .disablePlugins(MimaPlugin)
   .settings(
+    // TODO Remove when pekko-paradox-sbt has its first release
+    resolvers += Resolver.ApacheMavenSnapshotsRepo,
+    updateOptions := updateOptions.value.withLatestSnapshots(false),
     Compile / paradox / name := "Apache Pekko Connectors",
     publish / skip := true,
     pekkoParadoxGithub := Some("https://github.com/apache/incubator-pekko-connectors"),


### PR DESCRIPTION
We are not relying on snapshots anymore so we can remove the repository