### PR TITLE
remove unnecessary imports

### DIFF
--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/WriteSettingsBase.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/WriteSettingsBase.scala
@@ -13,10 +13,6 @@
 
 package org.apache.pekko.stream.connectors.elasticsearch
 
-import org.apache.pekko
-import pekko.stream.connectors.elasticsearch.ElasticsearchConnectionSettings
-import pekko.stream.connectors.elasticsearch.RetryLogic
-
 /**
  * Configure Elasticsearch/OpenSearch sinks and flows.
  */


### PR DESCRIPTION
Scala compiler warns about these imports