### PR TITLE
upgrade aws libs

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val InfluxDBJavaVersion = "2.15"
 
   val AvroVersion = "1.11.3"
-  val AwsSdk2Version = "2.20.162"
+  val AwsSdk2Version = "2.23.11"
   val AwsSpiPekkoHttpVersion = "0.1.0"
   val NettyVersion = "4.1.104.Final"
   // Sync with plugins.sbt

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val InfluxDBJavaVersion = "2.15"
 
   val AvroVersion = "1.11.3"
-  val AwsSdk2Version = "2.17.113"
+  val AwsSdk2Version = "2.20.162"
   val AwsSpiPekkoHttpVersion = "0.1.0"
   val NettyVersion = "4.1.104.Final"
   // Sync with plugins.sbt


### PR DESCRIPTION
* may not be that useful - I thought aws sdk used netty but it seems to just use it in test cases
* still may be useful to upgrade but maybe only in pekko-connectors 1.1.0