### PR TITLE
 Properly fix versioning for Pekko dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val ScalaVersions = Seq(Scala213, Scala212, Scala3)
 
   val PekkoVersion = "1.0.1"
-  val PekkoBinaryVersion = "current"
+  val PekkoBinaryVersion = "1.0"
 
   val InfluxDBJavaVersion = "2.15"
 
@@ -30,9 +30,9 @@ object Dependencies {
   val AwsSpiPekkoHttpVersion = "0.1.0"
   val NettyVersion = "4.1.100.Final"
   // Sync with plugins.sbt
-  val PekkoGrpcBinaryVersion = "current"
+  val PekkoGrpcBinaryVersion = "1.0"
   val PekkoHttpVersion = "1.0.0"
-  val PekkoHttpBinaryVersion = "current"
+  val PekkoHttpBinaryVersion = "1.0"
   val ScalaTestVersion = "3.2.14"
   val TestContainersScalaTestVersion = "0.40.14"
   val mockitoVersion = "4.2.0" // check even https://github.com/scalatest/scalatestplus-mockito/releases


### PR DESCRIPTION
There was a regression in https://github.com/apache/incubator-pekko-connectors/commit/2b5fcd11937270d0995f788486cb9cc4216067fb#diff-ad2642dc77b3679e4ad2c7d3b2f59a2dcf48c1bf5b93a558a4fa44828315a34cR29 where the Pekko dependencies were set to "current" (likely because a grpc release wasn't made) but in reality its actually meant to be a statically hardcoded version.

You can use https://github.com/mdedetrich/alpakka-apache/blob/4ebf24a4f996b088b4ed16cee182accc5ac92e1c/project/Dependencies.scala#L16-L21 as a reference of how it looked like at last point before fork