### PR TITLE
Accept any materializer type param for S3's chunkUploadSink

### DIFF
--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala
@@ -906,7 +906,7 @@ import scala.util.{ Failure, Success, Try }
    */
   def multipartUploadWithContext[C](
       s3Location: S3Location,
-      chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), NotUsed],
+      chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), _],
       contentType: ContentType = ContentTypes.`application/octet-stream`,
       s3Headers: S3Headers,
       chunkSize: Int = MinChunkSize,
@@ -943,7 +943,7 @@ import scala.util.{ Failure, Success, Try }
       s3Location: S3Location,
       uploadId: String,
       previousParts: immutable.Iterable[Part],
-      chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), NotUsed],
+      chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), _],
       contentType: ContentType = ContentTypes.`application/octet-stream`,
       s3Headers: S3Headers,
       chunkSize: Int = MinChunkSize,
@@ -1216,7 +1216,7 @@ import scala.util.{ Failure, Success, Try }
       contentType: ContentType,
       s3Headers: S3Headers,
       chunkSize: Int,
-      chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), NotUsed],
+      chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), _],
       initialUploadState: Option[(String, Int)] = None)(
       parallelism: Int): Flow[(ByteString, C), UploadPartResponse, NotUsed] = {
 


### PR DESCRIPTION
When I originally added this functionality I mistakingly hardcoded the type parameter to `NotUsed` rather than just using `_` (which means don't care). While this may initially seem like a non-issue, a problem eventuates if you happen to use a `Sink` that materializes a value that is contained within a `Future` i.e. `Sink[(UploadPartResponse, immutable.Iterable[C]), Future[Done]]`. Such sinks are quite common and there is no way to get a value outside of a `Future` aside from blocking (which you should never do in production code) in order to satisfy `chunkUploadSink: Sink[(UploadPartResponse, immutable.Iterable[C]), NotUsed]`.

Note that since `chunkUploadSink` ultimately ends up [getting used in `.alsoTo`](https://github.com/apache/incubator-pekko-connectors/blob/18fc2932cf78194ea149bda0d9e73f7161b8e39f/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala#L1323) whos materializer type argument param is also `_` (see https://github.com/apache/incubator-pekko/blob/1b1f57224b409c8b2cbd5267ace814439e97d3ea/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Flow.scala#L3464) and the fact that we are only dealing with type parameters which get erased at runtime means that this change is completely safe for the 1.0.x series (in fact it shouldn't even generate any bytecode difference either way, all this does is make scalac satisfy code where the materializer type param is not `NotUsed`)