### PR TITLE
[DRAFT] upgrade jackson used in elasticsearch connector

### DIFF
--- a/elasticsearch/src/main/resources/reference.conf
+++ b/elasticsearch/src/main/resources/reference.conf
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+##############################################
+# Pekko Connectors ElasticSearch Config File #
+##############################################
+
+# This is the reference config file that contains all the default settings.
+# Make your edits/overrides in your application.conf.
+
+pekko.connectors.elasticsearch {
+  jackson {
+    read {
+      # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.0/com/fasterxml/jackson/core/StreamReadConstraints.html
+      # these defaults are the same as the defaults in `StreamReadConstraints`
+      max-nesting-depth = 1000
+      max-number-length = 1000
+      max-string-length = 20000000
+      max-name-length = 50000
+      # max-document-length of -1 means unlimited
+      max-document-length = -1
+    }
+    write {
+      # see https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-core/2.16.0/com/fasterxml/jackson/core/StreamWriteConstraints.html
+      # these defaults are the same as the defaults in `StreamWriteConstraints`
+      max-nesting-depth = 1000
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -92,6 +92,11 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-core" % JacksonDatabindVersion,
     "com.fasterxml.jackson.core" % "jackson-databind" % JacksonDatabindVersion)
 
+  val JacksonDatabindVersion216 = "2.16.0"
+  val JacksonDatabindDependencies216 = Seq(
+    "com.fasterxml.jackson.core" % "jackson-core" % JacksonDatabindVersion216,
+    "com.fasterxml.jackson.core" % "jackson-databind" % JacksonDatabindVersion216)
+
   val Amqp = Seq(
     libraryDependencies ++= Seq(
       "com.rabbitmq" % "amqp-client" % "5.14.2") ++ Mockito)
@@ -152,7 +157,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-spray-json" % PekkoHttpVersion,
-      "org.slf4j" % "jcl-over-slf4j" % jclOverSlf4jVersion % Test) ++ JacksonDatabindDependencies)
+      "org.slf4j" % "jcl-over-slf4j" % jclOverSlf4jVersion % Test) ++ JacksonDatabindDependencies216)
 
   val File = Seq(
     libraryDependencies ++= Seq(


### PR DESCRIPTION
The plan is just to upgrade some connectors that use jackson explicitly. There are other connectors that use it transitively. The plan is not to change those (yet).