### PR TITLE
Update amqp-client to 5.20.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -94,7 +94,7 @@ object Dependencies {
 
   val Amqp = Seq(
     libraryDependencies ++= Seq(
-      "com.rabbitmq" % "amqp-client" % "5.14.2") ++ Mockito)
+      "com.rabbitmq" % "amqp-client" % "5.20.0") ++ Mockito)
 
   val AwsLambda = Seq(
     libraryDependencies ++= Seq(


### PR DESCRIPTION
Upgrade amqp-client to 5.20.0 due to CVE-2023-46120

details are given at: https://deps.dev/advisory/osv/GHSA-mm8h-8587-p46h

If I should create an issue, let me create and associate it with this issue. 

