### PR TITLE
increase cassandra test timeout

### DIFF
--- a/cassandra/src/test/java/docs/javadsl/CassandraTestHelper.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraTestHelper.java
@@ -65,7 +65,7 @@ public class CassandraTestHelper {
   }
 
   public static <T> T await(Future<T> future) {
-    int seconds = 20;
+    int seconds = 40;
     try {
       return Await.result(future, FiniteDuration.create(seconds, TimeUnit.SECONDS));
     } catch (InterruptedException e) {


### PR DESCRIPTION
Cassandra tests started failing recently and it isn't clear that any recent change is causing this. I tried reverting the logback upgrade but that didn't help.

This timeout change seems to help.