### PR TITLE
Update Scala 3 to 3.3.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
 
   val Scala213 = "2.13.12" // update even in link-validator.conf
   val Scala212 = "2.12.18"
-  val Scala3 = "3.3.1"
+  val Scala3 = "3.3.2-RC1"
   val ScalaVersions = Seq(Scala213, Scala212, Scala3)
 
   val PekkoVersion = "1.0.2"


### PR DESCRIPTION
Scala 3.3.2-RC1 just came out so this PR is testing it out to see if the codebase compiles. It will remain in draft until full release of Scala 3.3.2 is out.