### PR TITLE
Kinesis: fix maxBytesPerSecond throttling

### DIFF
--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/scaladsl/KinesisFlow.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/scaladsl/KinesisFlow.scala
@@ -104,8 +104,8 @@ object KinesisFlow {
       entries: Iterable[(PutRecordsRequestEntry, T)])(result: PutRecordsResponse): List[(PutRecordsResultEntry, T)] =
     result.records.asScala.toList.zip(entries).map { case (res, (_, t)) => (res, t) }
 
-  private def getPayloadByteSize[T](record: (PutRecordsRequestEntry, T)): Int = record match {
-    case (request, _) => request.partitionKey.length + request.data.asByteBuffer.position()
+  private[kinesis] def getPayloadByteSize[T](record: (PutRecordsRequestEntry, T)): Int = record match {
+    case (request, _) => request.partitionKey.length + request.data.asByteArrayUnsafe.length
   }
 
   def byPartitionAndData(

--- a/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisFlowSpec.scala
+++ b/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisFlowSpec.scala
@@ -66,6 +66,15 @@ class KinesisFlowSpec extends AnyWordSpec with Matchers with KinesisMock with Lo
         sinkProbe.expectError(FailurePublishingRecords(requestError))
       }
     }
+
+    "compute payload size" in {
+      val r = PutRecordsRequestEntry
+        .builder()
+        .partitionKey("")
+        .data(SdkBytes.fromByteBuffer(ByteString("data").asByteBuffer))
+        .build()
+      KinesisFlow.getPayloadByteSize((r, "")) shouldBe 4
+    }
   }
 
   "KinesisFlowWithUserContext" must {


### PR DESCRIPTION
The kinesis throttling is not being respected because the function `getPayloadByteSize` is incorrect. 

```scala
private def getPayloadByteSize[T](record: (PutRecordsRequestEntry, T)): Int = record match {
    case (request, _) => request.partitionKey.length + request.data.asByteBuffer.position()
}
```

`request.data.asByteBuffer.position()` can return 0

The ticket was originally reported in https://github.com/akka/alpakka/issues/2871 and I did the fix in the akka repository. AFAICT I can use the same code as long as I am the author...