### PR TITLE
Use designated Scala methods for converter utils

### DIFF
--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/ElasticsearchConnectionSettings.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/ElasticsearchConnectionSettings.scala
@@ -19,7 +19,6 @@ import pekko.http.scaladsl.model.HttpHeader
 import pekko.http.scaladsl.model.HttpHeader.ParsingResult
 import pekko.japi.Util
 import pekko.util.ccompat.JavaConverters._
-import pekko.util.OptionConverters
 import pekko.util.OptionConverters._
 
 import javax.net.ssl.SSLContext
@@ -72,8 +71,8 @@ final class ElasticsearchConnectionSettings private (
     val scalaContext = new HttpsConnectionContext(
       connectionContext.getSslContext,
       None,
-      OptionConverters.toScala(connectionContext.getEnabledCipherSuites).map(Util.immutableSeq(_)),
-      OptionConverters.toScala(connectionContext.getEnabledProtocols).map(Util.immutableSeq(_)),
+      connectionContext.getEnabledCipherSuites.toScala.map(Util.immutableSeq(_)),
+      connectionContext.getEnabledProtocols.toScala.map(Util.immutableSeq(_)),
       connectionContext.getClientAuth.toScala,
       connectionContext.getSslParameters.toScala)
 


### PR DESCRIPTION
This PR is a response to https://github.com/apache/incubator-pekko/pull/894, specifically rather than using the Java designed converter methods within Scala sources we use the Scala ones so that when the project is compiled with Scala 3 it gets inlined.