### PR TITLE
[slick][javadsl] improve SlickSession.forConfig usage with idea

### DIFF
--- a/slick/src/main/scala/org/apache/pekko/stream/connectors/slick/javadsl/package.scala
+++ b/slick/src/main/scala/org/apache/pekko/stream/connectors/slick/javadsl/package.scala
@@ -59,7 +59,12 @@ private[slick] abstract class SlickSessionFactory {
  * closed after creation to avoid leaking database resources like active
  * connection pools, etc.
  */
-object SlickSession extends SlickSessionFactory
+object SlickSession extends SlickSessionFactory {
+  override def forConfig(path: String) = super.forConfig(path)
+  override def forConfig(config: Config) = super.forConfig(config)
+  override def forConfig(path: String, config: Config) = super.forConfig(path, config)
+  override def forConfig(databaseConfig: DatabaseConfig[JdbcProfile]) = super.forConfig(databaseConfig)
+}
 
 /**
  * Java API: A class representing a slick resultset row, which is used


### PR DESCRIPTION
## motivation
If the Companion object `A` of `class A` extend  a class `B`, the idea will report an error, because idea can't find the method include the class `B`

![image](https://github.com/apache/incubator-pekko-connectors/assets/35491928/adfe9cda-db1f-469a-8d24-977fe0d83816)
user need to use `SlickSession$.MODULE$.forConfig("slick-h2");`, this usage connot match the description on the official website.

Report it to idea,but idea may not be fixed or slowly, as they are mainly Java ideas and cannot fix such issues. Previously reported an error with the inline.

## how to do
just wrapper the extend method

## test 
had test locally.