### PR TITLE
Use scope config for compute-engine auth

### DIFF
--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/ComputeEngineCredentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/ComputeEngineCredentials.scala
@@ -25,18 +25,19 @@ import scala.concurrent.Future
 @InternalApi
 private[auth] object ComputeEngineCredentials {
 
-  def apply()(implicit system: ClassicActorSystemProvider): Future[Credentials] =
+  def apply(scopes: Set[String])(implicit system: ClassicActorSystemProvider): Future[Credentials] = {
     GoogleComputeMetadata
       .getProjectId()
-      .map(new ComputeEngineCredentials(_))(system.classicSystem.dispatcher)
+      .map(projectId => new ComputeEngineCredentials(projectId, scopes))(system.classicSystem.dispatcher)
+  }
 
 }
 
 @InternalApi
-private final class ComputeEngineCredentials(projectId: String)(implicit mat: Materializer)
+private final class ComputeEngineCredentials(projectId: String, scopes: Set[String])(implicit mat: Materializer)
     extends OAuth2Credentials(projectId) {
   override protected def getAccessToken()(implicit mat: Materializer,
       settings: RequestSettings,
       clock: Clock): Future[AccessToken] =
-    GoogleComputeMetadata.getAccessToken()
+    GoogleComputeMetadata.getAccessToken(scopes)
 }

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/Credentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/Credentials.scala
@@ -20,6 +20,7 @@ import pekko.event.Logging
 import pekko.http.scaladsl.model.headers.HttpCredentials
 import pekko.stream.connectors.google.RequestSettings
 import pekko.util.JavaDurationConverters._
+import pekko.util.ccompat.JavaConverters._
 import com.google.auth.{ Credentials => GoogleCredentials }
 import com.typesafe.config.Config
 
@@ -72,8 +73,10 @@ object Credentials {
   private def parseServiceAccount(c: Config)(implicit system: ClassicActorSystemProvider) =
     ServiceAccountCredentials(c.getConfig("service-account"))
 
-  private def parseComputeEngine(c: Config)(implicit system: ClassicActorSystemProvider) =
-    Await.result(ComputeEngineCredentials(), c.getDuration("compute-engine.timeout").asScala)
+  private def parseComputeEngine(c: Config)(implicit system: ClassicActorSystemProvider) = {
+    val scopes = c.getStringList("scopes").asScala.toSet
+    Await.result(ComputeEngineCredentials(scopes), c.getDuration("compute-engine.timeout").asScala)
+  }
 
   private def parseUserAccess(c: Config)(implicit system: ClassicActorSystemProvider) =
     UserAccessCredentials(c.getConfig("user-access"))


### PR DESCRIPTION
Currently when getting Google credentials using the `ComputeEngineCredentials` method, it ignores the [`scopes`](https://github.com/apache/incubator-pekko-connectors/blob/1fe3474d654bf48b0e81011d878e541a32409c93/google-common/src/main/resources/reference.conf#L9) variable.

In the official Google SDK, you can see that it also has the same logic for getting the credentials from `ComputeEngine`, see https://github.com/googleapis/google-auth-library-java/blob/a7a8d7a4102b0b7c1b83791947ccb662f060eca7/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java#L193-L199 and https://github.com/googleapis/google-auth-library-java/blob/a7a8d7a4102b0b7c1b83791947ccb662f060eca7/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java#L480-L483 (which is the same URI as https://github.com/apache/incubator-pekko-connectors/blob/67eea4f1dc7e9e0931322ef5c07f305e995b0eb2/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/GoogleComputeMetadata.scala#L33-L34)