### PR TITLE
Remove duplicate scopes value in reference.conf

### DIFF
--- a/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/model.scala
+++ b/google-cloud-pub-sub/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/model.scala
@@ -71,7 +71,7 @@ object PubSubConfig {
           projectId = projectId,
           credentials =
             ServiceAccountCredentials(projectId, clientEmail, privateKey,
-              Seq("https://www.googleapis.com/auth/pubsub")))))
+              Set("https://www.googleapis.com/auth/pubsub")))))
 
   /**
    * @deprecated Use [[pekko.stream.connectors.google.GoogleSettings]] to manage credentials
@@ -93,7 +93,7 @@ object PubSubConfig {
           projectId = projectId,
           credentials =
             ServiceAccountCredentials(projectId, clientEmail, privateKey,
-              Seq("https://www.googleapis.com/auth/pubsub")))))
+              Set("https://www.googleapis.com/auth/pubsub")))))
 
   /**
    * Java API

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStream.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStream.scala
@@ -312,7 +312,7 @@ import scala.concurrent.{ ExecutionContext, Future }
         && (legacySettings.tokenUrl.contains("googleapis.com") || legacySettings.tokenUrl == "unsupported"),
         "Non-default base-url/base-path/token-url no longer supported, use config path pekko.connectors.google.forward-proxy")
 
-      val legacyScopes = legacySettings.tokenScope.split(" ").toList
+      val legacyScopes = legacySettings.tokenScope.split(" ").toSet
       val credentials = Credentials.cache(
         (
           legacySettings.projectId,

--- a/google-common/src/main/resources/reference.conf
+++ b/google-common/src/main/resources/reference.conf
@@ -27,9 +27,6 @@ pekko.connectors.google {
       path = ${?CLOUDSDK_CONFIG}
       path = ${pekko.connectors.google.credentials.service-account.path}/application_default_credentials.json
       path = ${?GOOGLE_APPLICATION_CREDENTIALS}
-
-      # Always required regardless of where credentials are read from
-      scopes = ${pekko.connectors.google.credentials.scopes}
     }
 
     # Timeout for blocking call during settings initialization to compute engine metadata server

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/Credentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/Credentials.scala
@@ -20,6 +20,7 @@ import pekko.event.Logging
 import pekko.http.scaladsl.model.headers.HttpCredentials
 import pekko.stream.connectors.google.RequestSettings
 import pekko.util.JavaDurationConverters._
+import pekko.util.ccompat.JavaConverters._
 import com.google.auth.{ Credentials => GoogleCredentials }
 import com.typesafe.config.Config
 
@@ -69,8 +70,10 @@ object Credentials {
     case "none"            => parseNone(c)
   }
 
-  private def parseServiceAccount(c: Config)(implicit system: ClassicActorSystemProvider) =
-    ServiceAccountCredentials(c.getConfig("service-account"))
+  private def parseServiceAccount(c: Config)(implicit system: ClassicActorSystemProvider) = {
+    val scopes = c.getStringList("scopes").asScala.toSet
+    ServiceAccountCredentials(c.getConfig("service-account"), scopes)
+  }
 
   private def parseComputeEngine(c: Config)(implicit system: ClassicActorSystemProvider) =
     Await.result(ComputeEngineCredentials(), c.getDuration("compute-engine.timeout").asScala)

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/GoogleOAuth2.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/GoogleOAuth2.scala
@@ -37,7 +37,7 @@ private[auth] object GoogleOAuth2 {
 
   private val oAuthTokenUrl = "https://oauth2.googleapis.com/token"
 
-  def getAccessToken(clientEmail: String, privateKey: String, scopes: Seq[String])(
+  def getAccessToken(clientEmail: String, privateKey: String, scopes: Set[String])(
       implicit mat: Materializer,
       settings: RequestSettings,
       clock: Clock): Future[AccessToken] = {
@@ -58,7 +58,7 @@ private[auth] object GoogleOAuth2 {
     }
   }
 
-  private def generateJwt(clientEmail: String, privateKey: String, scopes: Seq[String])(
+  private def generateJwt(clientEmail: String, privateKey: String, scopes: Set[String])(
       implicit clock: Clock): String = {
     import spray.json._
 

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/GoogleOAuth2Spec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/GoogleOAuth2Spec.scala
@@ -58,7 +58,7 @@ class GoogleOAuth2Spec
     Source.fromInputStream(inputStream).getLines().mkString("\n").stripMargin
   }
 
-  val scopes = Seq("https://www.googleapis.com/auth/service")
+  val scopes = Set("https://www.googleapis.com/auth/service")
 
   "GoogleTokenApi" should {
 

--- a/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/impl/FcmFlows.scala
+++ b/google-fcm/src/main/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/impl/FcmFlows.scala
@@ -66,7 +66,7 @@ private[fcm] object FcmFlows {
   @Deprecated
   private def resolveSettings(conf: FcmSettings)(mat: Materializer, attr: Attributes): GoogleSettings = {
     val settings = GoogleAttributes.resolveSettings(mat, attr)
-    val scopes = List("https://www.googleapis.com/auth/firebase.messaging")
+    val scopes = Set("https://www.googleapis.com/auth/firebase.messaging")
     val credentials =
       if (conf.privateKey == "deprecated")
         settings.credentials


### PR DESCRIPTION
While working on https://github.com/apache/incubator-pekko-connectors/pull/313 I realized that we have duplicate scope configuration settings, i.e. one [here](https://github.com/apache/incubator-pekko-connectors/blob/1fe3474d654bf48b0e81011d878e541a32409c93/google-common/src/main/resources/reference.conf#L9) and another [here](https://github.com/apache/incubator-pekko-connectors/blob/1fe3474d654bf48b0e81011d878e541a32409c93/google-common/src/main/resources/reference.conf#L31-L32).

This PR removes the scopes config [here](https://github.com/apache/incubator-pekko-connectors/blob/1fe3474d654bf48b0e81011d878e541a32409c93/google-common/src/main/resources/reference.conf#L31-L32) and instead makes the `ServiceAccountCredentials` use the scopes value from [here](https://github.com/apache/incubator-pekko-connectors/blob/1fe3474d654bf48b0e81011d878e541a32409c93/google-common/src/main/resources/reference.conf#L9) which is currently unused.

We also change the collection from a `Seq`/`List` to a `Set` since we want duplicates to be removed and ordering does not matter (also to make it consistent with https://github.com/apache/incubator-pekko-connectors/pull/313)