### PR TITLE
Add PekkoHttpDependency from sbt-pekko-build

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
   val NettyVersion = "4.1.104.Final"
   // Sync with plugins.sbt
   val PekkoGrpcBinaryVersion = "1.0"
-  val PekkoHttpVersion = "1.0.0"
+  val PekkoHttpVersion = PekkoHttpDependency.version
   val PekkoHttpBinaryVersion = "1.0"
   val ScalaTestVersion = "3.2.14"
   val TestContainersScalaTestVersion = "0.40.14"

--- a/project/PekkoHttpDependency.scala
+++ b/project/PekkoHttpDependency.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.github.pjfanning.pekkobuild.PekkoDependency
+
+object PekkoHttpDependency extends PekkoDependency {
+  override val checkProject: String = "pekko-http-testkit"
+  override val module: Option[String] = Some("http")
+  override val currentVersion: String = "1.0.0"
+}


### PR DESCRIPTION
Just like with pekko core, adds a dynamic dependency for pekko-http to pekko-connectors so we make sure that pekko-connectors continue to work against new versions of pekko-http (connectors uses pekko-http heavily so we should be doing this).