### PR TITLE
Update sbt-pekko-build to 0.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCh
 // pekkoInlineEnabled should be set to true when we start building 1.1.x builds
 ThisBuild / pekkoInlineEnabled := false
 
-ThisBuild / apacheSonatypeProjectProfile := "pekko"
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := true
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,9 +12,8 @@ dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.2.0"
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.31")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.11")
-addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.0")
+addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.1")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 // discipline
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")


### PR DESCRIPTION
Updates sbt-pekko-build to 0.3.1 which brings in the pom.xml `name` field fix