### PR TITLE
protect 1.0.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,6 +41,18 @@ github:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
         required_approving_review_count: 1
+    1.0.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1        
 
 notifications:
   commits:              commits@pekko.apache.org

--- a/.github/workflows/nightly-pekko-1.1-builds.yaml
+++ b/.github/workflows/nightly-pekko-1.1-builds.yaml
@@ -40,4 +40,4 @@ jobs:
         uses: coursier/cache-action@v6.4.0
 
       - name: "compile, including  tests. Run locally with: sbt -Dpekko.build.pekko.version=main +Test/compile"
-        run: sbt -Dpekko.build.pekko.version=main +Test/compile
+        run: sbt -Dpekko.build.pekko.version=main -Dpekko.build.pekko.http.version=main +Test/compile

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
+          ref: 1.0.x
 
       - name: Setup Java 8
         uses: actions/setup-java@v4


### PR DESCRIPTION
also updates job for 1.0 doc publishing to use v1.0.2 (latest release)