### PR TITLE
mima compare version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -441,6 +441,8 @@ lazy val `doc-examples` = project
     publish / skip := true,
     Dependencies.`Doc-examples`)
 
+val mimaCompareVersion = "1.0.2"
+
 def pekkoConnectorProject(projectId: String,
     moduleName: String,
     additionalSettings: sbt.Def.SettingsDefinition*): Project = {
@@ -453,8 +455,7 @@ def pekkoConnectorProject(projectId: String,
       licenses := List(License.Apache2),
       AutomaticModuleName.settings(s"pekko.stream.connectors.$moduleName"),
       mimaPreviousArtifacts := Set(
-        organization.value %% name.value % previousStableVersion.value
-          .getOrElse("0.0.0")),
+        organization.value %% name.value % mimaCompareVersion),
       mimaBinaryIssueFilters ++= Seq(
         ProblemFilters.exclude[Problem]("*.impl.*"),
         // generated code


### PR DESCRIPTION
we are getting issues in `main` branch builds with mima checks - since the v1.1.0-M0 git tag was added

see https://github.com/apache/incubator-pekko-connectors/actions/runs/7678675966/job/20928810106

the issue is because the current setup uses the git tags and expects there to be releases for every git tag

We can test with "1.0.2" for the time being

I raised https://github.com/sbt/sbt-dynver/issues/283 to possibly do a change there so that we could go back to using the `previousStableVersion` sbt variable.