### PR TITLE
Enable inliner

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,9 +9,6 @@
 
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 
-// pekkoInlineEnabled should be set to true when we start building 1.1.x builds
-ThisBuild / pekkoInlineEnabled := false
-
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := true
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo


### PR DESCRIPTION
Enable the inliner since this is now 1.1.x. @pjfanning I know you were sensitive about explicitly setting this to `true` to make it more clear but doing so disables the knob/cli flag at https://github.com/pjfanning/sbt-pekko-build/blob/main/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlinePlugin.scala#L56 and I don't think explicitly setting `pekkoInlineEnabled` is having much of an effect either way on developers.

If you still want me to explicitly set it to `true` then let me know and ill update the PR.