### PR TITLE
use kudu 1.10.1 libs

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -337,7 +337,7 @@ object Dependencies {
         ExclusionRule("software.amazon.awssdk", "netty-nio-client"))) ++ Seq(
       "ch.qos.logback" % "logback-classic" % LogbackForSlf4j2Version % Test) ++ Mockito)
 
-  val KuduVersion = "1.7.1"
+  val KuduVersion = "1.14.0"
   val Kudu = Seq(
     libraryDependencies ++= Seq(
       "org.apache.kudu" % "kudu-client-tools" % KuduVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -337,7 +337,7 @@ object Dependencies {
         ExclusionRule("software.amazon.awssdk", "netty-nio-client"))) ++ Seq(
       "ch.qos.logback" % "logback-classic" % LogbackForSlf4j2Version % Test) ++ Mockito)
 
-  val KuduVersion = "1.14.0"
+  val KuduVersion = "1.10.1"
   val Kudu = Seq(
     libraryDependencies ++= Seq(
       "org.apache.kudu" % "kudu-client-tools" % KuduVersion,


### PR DESCRIPTION
* latest kudu libs cause us build problems
* idea is to upgrade to 1.10.1 and investigate further upgrades after that
* I can build with versions newer than 1.10.1 (up to 1.14.0) but the tests fail with 

```
[org.apache.pekko.stream.connectors.kudu.impl.KuduFlowStage$$anon$1-KuduFLow]: the number of replicas does not equal the number of servers
java.lang.IllegalArgumentException: the number of replicas does not equal the number of servers
	at org.apache.kudu.shaded.com.google.common.base.Preconditions.checkArgument(Preconditions.java:142)
	at org.apache.kudu.client.RemoteTablet.<init>(RemoteTablet.java:78)
	at org.apache.kudu.client.AsyncKuduClient.discoverTablets(AsyncKuduClient.java:2412)
	at org.apache.kudu.client.AsyncKuduClient$MasterLookupCB.call(AsyncKuduClient.java:2291)
	at org.apache.kudu.client.AsyncKuduClient$MasterLookupCB.call(AsyncKuduClient.java:2272)
```