### PR TITLE
use apache cassandra driver

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -115,15 +115,12 @@ object Dependencies {
       "com.microsoft.azure" % "azure-storage" % "8.6.6"))
 
   val CassandraVersionInDocs = "4.0"
-  val CassandraDriverVersion = "4.17.0"
+  val CassandraDriverVersion = "4.18.0"
   val CassandraDriverVersionInDocs = "4.17"
 
   val Cassandra = Seq(
     libraryDependencies ++= JacksonDatabindDependencies ++ Seq(
-      ("com.datastax.oss" % "java-driver-core" % CassandraDriverVersion)
-        .exclude("com.github.spotbugs", "spotbugs-annotations")
-        .exclude("org.apache.tinkerpop", "*") // https://github.com/akka/alpakka/issues/2200
-        .exclude("com.esri.geometry", "esri-geometry-api"), // https://github.com/akka/alpakka/issues/2225
+      "org.apache.cassandra" % "java-driver-core" % CassandraDriverVersion,
       "io.netty" % "netty-handler" % NettyVersion,
       "org.apache.pekko" %% "pekko-discovery" % PekkoVersion % Provided))
 


### PR DESCRIPTION
The datastax driver has been donated to the ASF. The 4.18.0 release does not seem to have any significant changes from 4.17.0 (last datastax release). Even the package names in the code haven't changed yet.

The excludes in the sbt have no effect because the transitive dependencies are optional.

see https://github.com/apache/incubator-pekko-connectors/issues/202