### PR TITLE
Move sbt-paradox to pinned updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,11 +11,12 @@ updates.pin  = [
   { groupId = "org.apache.activemq", version = "5.16." }
   # wiremock 3.0+ requires Java 11 (only used in tests)
   { groupId = "com.github.tomakehurst", version = "2." }
+  # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info", version = "0.9." },
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
 ]
 
 updates.ignore = [
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info" }
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox "}
   # https://github.com/apache/incubator-pekko-connectors/issues/61
   { groupId = "org.apache.hbase" }
   { groupId = "org.apache.hadoop" }


### PR DESCRIPTION
We can still use sbt-paradox/sbt-paradox-project-info, just needs to be 0.9.x series