### PR TITLE
Fix excludes for sbt-site-paradox

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,10 +23,11 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.8.0")
 
 resolvers += Resolver.ApacheMavenSnapshotsRepo
 addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.1-RC1+3-2b1f8708-SNAPSHOT")
+addSbtPlugin(("com.github.sbt" % "sbt-site-paradox" % "1.5.0").excludeAll(
+  "com.lightbend.paradox", "sbt-paradox"))
 
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
-addSbtPlugin(("com.github.sbt" % "sbt-site-paradox" % "1.5.0").exclude("com.typesafe.sbt", "sbt-web"))
 // Pekko gRPC -- sync with PekkoGrpcBinaryVersion in Dependencies.scala
 addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.2")
 // templating


### PR DESCRIPTION
The previous [PR](https://github.com/apache/incubator-pekko-connectors/pull/536) forgot to fix the excludes for `sbt-site-paradox`.

Ordinarily we would fix this in https://github.com/apache/incubator-pekko-sbt-paradox/blob/main/build.sbt#L76-L88 however it seems to be only pekko-connectors that uses `sbt-site-paradox` and since its an sbt plugin that [automatically loads](https://github.com/sbt/sbt-site/blob/main/core/src/main/scala/com/typesafe/sbt/site/SitePlugin.scala#L9) adding it to pekko-sbt-paradox isn't appropriate (this is also the reason why we have cases in pekko-connectors where the plugin is [explicitly disabled](https://github.com/apache/incubator-pekko-connectors/blob/main/build.sbt#L22))