### PR TITLE
Update link-validator.conf due to Scala 2.13.13

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -41,7 +41,7 @@ site-link-validator {
     "http://www.thedevpiece.com/"
     # genereated by @apidoc
     "http://pravega.io/"
-    "http://www.scala-lang.org/api/2.13.12/scala/concurrent/Future.html"
-    "http://www.scala-lang.org/api/2.13.12/scala/util/Try.html"
+    "http://www.scala-lang.org/api/2.13.13/scala/concurrent/Future.html"
+    "http://www.scala-lang.org/api/2.13.13/scala/util/Try.html"
   ]
 }


### PR DESCRIPTION
Due to https://github.com/apache/incubator-pekko-connectors/pull/517, will also need to be backported after https://github.com/apache/incubator-pekko-connectors/pull/555 is merged