### PR TITLE
stick with jackson 2.16

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,7 +1,7 @@
 updates.pin  = [
   # pin to hadoop 3.3.x until 3.4.x beomes more widely adopted
   { groupId = "org.apache.hadoop", version = "3.3." }
-  # pin to jackson 2.16.x until 2.17.x beomes more stable
+  # pin to jackson 2.16.x until 2.17.x becomes more stable
   { groupId = "com.fasterxml.jackson.core", version = "2.16." }
   { groupId = "com.fasterxml.jackson.datatype", version = "2.16." }
   { groupId = "com.fasterxml.jackson.module", version = "2.16." }

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,6 +1,10 @@
 updates.pin  = [
   # pin to hadoop 3.3.x until 3.4.x beomes more widely adopted
   { groupId = "org.apache.hadoop", version = "3.3." }
+  # pin to jackson 2.16.x until 2.17.x beomes more stable
+  { groupId = "com.fasterxml.jackson.core", version = "2.16." }
+  { groupId = "com.fasterxml.jackson.datatype", version = "2.16." }
+  { groupId = "com.fasterxml.jackson.module", version = "2.16." }
   # spring-boot 3 requires Java 17
   { groupId = "org.springframework.boot", version = "2." }
   # spring-framework 6 requires Java 17


### PR DESCRIPTION
problems in jackson 2.17 include
* perf issues due to change in buffer recycler default
* bug when parsing numbers that have no digit before the decimal point
* stray compile dependency on bytebuffer - should have been test scope